### PR TITLE
fix(checkout): use in-scope data for card creation

### DIFF
--- a/src/lib/effect/membership.service.ts
+++ b/src/lib/effect/membership.service.ts
@@ -235,18 +235,29 @@ const make = Effect.gen(function* () {
           `Membership created: ${subscriptionId} for user ${userDocId}, plan: ${planType}`,
         );
 
-        // Create the membership card now that user + membership exist
-        const user = yield* db.getUser(userDocId);
-        const membership = yield* db.getActiveMembership(userDocId);
-
-        if (user && membership) {
-          yield* cardService.createCard({userId: userDocId, user, membership});
-          yield* Effect.log(`Membership card created for user ${userDocId}`);
-        } else {
-          yield* Effect.logWarning(
-            `Skipping card creation — user or membership not found after insert for ${userDocId}`,
-          );
-        }
+        // Create the membership card using data already in scope
+        yield* cardService.createCard({
+          userId: userDocId,
+          user: {
+            id: userDocId,
+            email: customerEmail || '',
+            name: undefined,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          membership: {
+            id: subscriptionId,
+            stripeSubscriptionId: subscriptionId,
+            planType,
+            status: subscription.status as MembershipStatus,
+            startDate: new Date(currentPeriodStart * 1000).toISOString(),
+            endDate: new Date(currentPeriodEnd * 1000).toISOString(),
+            autoRenew: !subscription.cancel_at_period_end,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        });
+        yield* Effect.log(`Membership card created for user ${userDocId}`);
       }),
 
     // Webhook: customer.subscription.updated


### PR DESCRIPTION
## Summary
- Fixes card not being created on `checkout.session.completed` webhook
- Root cause: `getActiveMembership()` filters by status `['active', 'trialing', 'past_due']` — if the subscription status didn't match at query time (e.g. resent webhook for a since-canceled subscription), it returned `null` and card creation was silently skipped
- Fix: pass the user and membership data already in scope directly to `createCard()` instead of re-querying the database

## Test plan
- [ ] Trigger checkout.session.completed webhook and verify `membership_cards` row is created
- [ ] Resend a webhook for a canceled subscription and verify card is still created
- [ ] All 247 unit tests pass