### PR TITLE
Cache Meetup rides for four hours

### DIFF
--- a/src/lib/meetup/events.ts
+++ b/src/lib/meetup/events.ts
@@ -1,4 +1,5 @@
 import {asc, gt} from 'drizzle-orm';
+import {unstable_cache} from 'next/cache';
 
 import {meetupEvents} from '@/src/db/schema/tables';
 
@@ -26,30 +27,42 @@ const formatRideMeta = (date: Date, location: string | null) => {
   return location ? `${formattedDate} · ${location}` : formattedDate;
 };
 
-export async function getUpcomingMeetupRides(limit = 5): Promise<UpcomingMeetupRide[]> {
-  try {
-    const db = getDb();
-    const rows = await db
-      .select({
-        title: meetupEvents.title,
-        link: meetupEvents.url,
-        startDate: meetupEvents.startDate,
-        location: meetupEvents.location,
-      })
-      .from(meetupEvents)
-      .where(gt(meetupEvents.startDate, new Date()))
-      .orderBy(asc(meetupEvents.startDate))
-      .limit(limit);
+const FOUR_HOURS_IN_SECONDS = 60 * 60 * 4;
 
-    return rows.map((row) => ({
-      title: row.title,
-      link: row.link,
-      date: row.startDate.toISOString(),
-      meta: formatRideMeta(row.startDate, row.location),
-      location: row.location,
-    }));
-  } catch (error) {
-    console.error('Failed to load upcoming Meetup rides from Neon:', error);
-    return [];
-  }
+const getUpcomingMeetupRidesCached = unstable_cache(
+  async (limit: number): Promise<UpcomingMeetupRide[]> => {
+    try {
+      const db = getDb();
+      const rows = await db
+        .select({
+          title: meetupEvents.title,
+          link: meetupEvents.url,
+          startDate: meetupEvents.startDate,
+          location: meetupEvents.location,
+        })
+        .from(meetupEvents)
+        .where(gt(meetupEvents.startDate, new Date()))
+        .orderBy(asc(meetupEvents.startDate))
+        .limit(limit);
+
+      return rows.map((row) => ({
+        title: row.title,
+        link: row.link,
+        date: row.startDate.toISOString(),
+        meta: formatRideMeta(row.startDate, row.location),
+        location: row.location,
+      }));
+    } catch (error) {
+      console.error('Failed to load upcoming Meetup rides from Neon:', error);
+      return [];
+    }
+  },
+  ['upcoming-meetup-rides'],
+  {
+    revalidate: FOUR_HOURS_IN_SECONDS,
+  },
+);
+
+export async function getUpcomingMeetupRides(limit = 5): Promise<UpcomingMeetupRide[]> {
+  return getUpcomingMeetupRidesCached(limit);
 }


### PR DESCRIPTION
## Summary
- wrap the upcoming Meetup rides Neon query in Next server cache
- revalidate the rides data every four hours instead of forcing the whole homepage dynamic

## Validation
- `pnpm tsc`
- `pnpm lint`