### PR TITLE
Add organizer role access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".repos/effect"]
+	path = .repos/effect
+	url = https://github.com/Effect-TS/effect-smol

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ The following environment variables need to be set in Netlify:
 - `STRIPE_WEBHOOK_SECRET`: Stripe webhook signing secret
 - `STRIPE_PRICE_INDIVIDUAL`: Stripe price ID for individual membership
 - `STRIPE_PRICE_FAMILY`: Stripe price ID for family membership
+- `ADMIN_EMAIL`: The single administrator account email. Organizer access is granted to member
+  accounts from the administrator dashboard.
 
 ### Encrypted Credentials
 

--- a/app/api/admin/check/route.ts
+++ b/app/api/admin/check/route.ts
@@ -2,6 +2,7 @@ import {Effect} from 'effect';
 import {cookies} from 'next/headers';
 import {NextResponse} from 'next/server';
 
+import {getDashboardCapabilities} from '@/src/lib/access-control';
 import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
 
 export async function GET() {
@@ -15,9 +16,17 @@ export async function GET() {
   return handleAdminRoute({
     handler: (admin, sessionCookie) =>
       Effect.gen(function* () {
-        const adminUser = yield* admin.verifyAdmin(sessionCookie);
-        return {isAdmin: true, authenticated: true, uid: adminUser.uid, email: adminUser.email};
-      }).pipe(Effect.catchAll(() => Effect.succeed({isAdmin: false, authenticated: true}))),
-    errorTags: [],
+        const access = yield* admin.getAccess(sessionCookie);
+        return {
+          authenticated: true,
+          isAdmin: access.role === 'admin',
+          isStaff: access.role === 'admin' || access.role === 'organizer',
+          uid: access.uid,
+          email: access.email,
+          role: access.role,
+          capabilities: getDashboardCapabilities(access.role),
+        };
+      }),
+    errorTags: ['SessionError', 'AuthError', 'DatabaseError'],
   });
 }

--- a/app/api/admin/export/route.ts
+++ b/app/api/admin/export/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: NextRequest) {
             const exportService = yield* ExportService;
 
             // Verify admin access
-            yield* admin.verifyAdmin(sessionCookie);
+            yield* admin.authorize(sessionCookie, 'members:export');
 
             // Generate export
             if (options.format === 'csv') {

--- a/app/api/admin/members/[userId]/audit/route.ts
+++ b/app/api/admin/members/[userId]/audit/route.ts
@@ -10,7 +10,7 @@ export async function GET(_request: NextRequest, {params}: {params: Promise<{use
   return handleAdminRoute({
     handler: (admin, sessionCookie) =>
       Effect.gen(function* () {
-        yield* admin.verifyAdmin(sessionCookie);
+        yield* admin.authorize(sessionCookie, 'members:audit');
         return yield* admin.getMemberAuditLog(userId);
       }),
     errorTags: [

--- a/app/api/admin/members/[userId]/reset-password/route.ts
+++ b/app/api/admin/members/[userId]/reset-password/route.ts
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest, {params}: {params: Promise<{use
   return handleAdminRoute({
     handler: (admin, sessionCookie) =>
       Effect.gen(function* () {
-        yield* admin.verifyAdmin(sessionCookie);
+        yield* admin.authorize(sessionCookie, 'members:password-reset');
         yield* admin.sendPasswordReset(userId);
         return {sent: true};
       }),

--- a/app/api/admin/members/expiring/route.ts
+++ b/app/api/admin/members/expiring/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest) {
   return handleAdminRoute({
     handler: (admin, sessionCookie) =>
       Effect.gen(function* () {
-        yield* admin.verifyAdmin(sessionCookie);
+        yield* admin.authorize(sessionCookie, 'members:read');
         return yield* admin.getExpiringMemberships(days as 30 | 60 | 90);
       }),
     errorTags: ['UnauthorizedError', 'SessionError', 'AuthError', 'DatabaseError'],

--- a/app/api/admin/members/route.ts
+++ b/app/api/admin/members/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     handler: (admin, sessionCookie) =>
       Effect.gen(function* () {
         // Verify admin access
-        yield* admin.verifyAdmin(sessionCookie);
+        yield* admin.authorize(sessionCookie, 'members:read');
 
         // Search members
         return yield* admin.searchMembers(params);

--- a/app/api/admin/organizers/[userId]/route.ts
+++ b/app/api/admin/organizers/[userId]/route.ts
@@ -1,0 +1,36 @@
+import {Effect} from 'effect';
+import {NextRequest} from 'next/server';
+
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+
+export async function PATCH(request: NextRequest, {params}: {params: Promise<{userId: string}>}) {
+  const {userId} = await params;
+  const body: unknown = await request.json();
+  const isOrganizer =
+    typeof body === 'object' &&
+    body !== null &&
+    'isOrganizer' in body &&
+    typeof body.isOrganizer === 'boolean'
+      ? body.isOrganizer
+      : null;
+
+  if (isOrganizer === null) {
+    return Response.json({error: 'isOrganizer must be a boolean'}, {status: 400});
+  }
+
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        yield* admin.setOrganizerRole(sessionCookie, userId, isOrganizer);
+        return {success: true, isOrganizer};
+      }),
+    errorTags: [
+      'UnauthorizedError',
+      'SessionError',
+      'AuthError',
+      'DatabaseError',
+      'NotFoundError',
+      'AdminError',
+    ],
+  });
+}

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
     handler: (admin, sessionCookie) =>
       Effect.gen(function* () {
         const stats = yield* StatsService;
-        yield* admin.verifyAdmin(sessionCookie);
+        yield* admin.authorize(sessionCookie, 'stats:read');
         return yield* stats.getStats();
       }),
     errorTags: ['UnauthorizedError', 'SessionError', 'AuthError', 'DatabaseError'],
@@ -21,7 +21,7 @@ export async function POST() {
     handler: (admin, sessionCookie) =>
       Effect.gen(function* () {
         const stats = yield* StatsService;
-        yield* admin.verifyAdmin(sessionCookie);
+        yield* admin.authorize(sessionCookie, 'stats:refresh');
         return yield* stats.refreshStats();
       }),
     errorTags: ['UnauthorizedError', 'SessionError', 'AuthError', 'DatabaseError'],

--- a/app/api/membership/[userId]/route.ts
+++ b/app/api/membership/[userId]/route.ts
@@ -1,8 +1,10 @@
 import {Effect, pipe} from 'effect';
+import {cookies} from 'next/headers';
 import {NextRequest, NextResponse} from 'next/server';
 
 import {LiveLayer} from '@/src/lib/effect/layers';
 import {MembershipService} from '@/src/lib/effect/membership.service';
+import {PortalService} from '@/src/lib/effect/portal.service';
 
 interface RouteParams {
   params: Promise<{userId: string}>;
@@ -15,10 +17,25 @@ export async function GET(request: NextRequest, {params}: RouteParams) {
     return NextResponse.json({error: 'User ID is required'}, {status: 400});
   }
 
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session')?.value;
+  if (!sessionCookie) {
+    return NextResponse.json({error: 'Not authenticated'}, {status: 401});
+  }
+
   const program = pipe(
-    Effect.flatMap(MembershipService, (membershipService) =>
-      membershipService.getMembershipStatus(userId),
-    ),
+    Effect.gen(function* () {
+      const portal = yield* PortalService;
+      const membershipService = yield* MembershipService;
+      const session = yield* portal.verifySession(sessionCookie);
+      if (session.uid !== userId) {
+        return yield* Effect.fail({
+          _tag: 'UnauthorizedError' as const,
+          message: 'You can only view your own membership',
+        });
+      }
+      return yield* membershipService.getMembershipStatus(userId);
+    }),
 
     Effect.catchTag('NotFoundError', (error) =>
       Effect.succeed({
@@ -33,6 +50,12 @@ export async function GET(request: NextRequest, {params}: RouteParams) {
         _tag: 'error' as const,
         status: 500,
       }),
+    ),
+    Effect.catchTag('SessionError', () =>
+      Effect.succeed({error: 'Session invalid', _tag: 'error' as const, status: 401}),
+    ),
+    Effect.catchTag('UnauthorizedError', (error) =>
+      Effect.succeed({error: error.message, _tag: 'error' as const, status: 403}),
     ),
   );
 

--- a/app/api/trails/[id]/route.ts
+++ b/app/api/trails/[id]/route.ts
@@ -1,52 +1,61 @@
-import {cookies} from 'next/headers';
+import {Effect} from 'effect';
 import {NextRequest, NextResponse} from 'next/server';
 
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+import {DatabaseError} from '@/src/lib/effect/errors';
 import {getFirestoreClient} from '@/src/lib/firestore-client';
 
-interface TrailUpdateData {
-  trail?: string;
-  open?: boolean;
-  notes?: string;
-}
-
 export async function PATCH(request: NextRequest, {params}: {params: Promise<{id: string}>}) {
-  try {
-    // Check authentication
-    const cookieStore = await cookies();
-    const authToken = cookieStore.get('session');
-
-    if (!authToken) {
-      return NextResponse.json({error: 'Authentication required'}, {status: 401});
-    }
-
-    // Get the trail ID from the URL params
-    const {id} = await params;
-    if (!id) {
-      return NextResponse.json({error: 'Trail ID is required'}, {status: 400});
-    }
-
-    // Parse the request body
-    const trailData: TrailUpdateData = await request.json();
-
-    const db = getFirestoreClient();
-
-    // Reference to the trail document
-    const trailRef = db.collection('trails').doc(id);
-
-    // Update the trail document
-    // Convert to a plain object to avoid TypeScript issues with Firestore
-    await trailRef.update(trailData as {[key: string]: any});
-
-    // Return success response
-    return NextResponse.json({success: true});
-  } catch (error) {
-    console.error('Error updating trail:', error);
-    return NextResponse.json(
-      {
-        error: 'Failed to update trail',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      {status: 500},
-    );
+  const {id} = await params;
+  if (!id) {
+    return NextResponse.json({error: 'Trail ID is required'}, {status: 400});
   }
+
+  const body: unknown = await request.json();
+  if (typeof body !== 'object' || body === null) {
+    return NextResponse.json({error: 'Invalid trail update'}, {status: 400});
+  }
+
+  const trailData: Record<string, string | boolean> = {};
+  if ('trail' in body) {
+    if (typeof body.trail !== 'string') {
+      return NextResponse.json({error: 'trail must be a string'}, {status: 400});
+    }
+    trailData.trail = body.trail;
+  }
+  if ('open' in body) {
+    if (typeof body.open !== 'boolean') {
+      return NextResponse.json({error: 'open must be a boolean'}, {status: 400});
+    }
+    trailData.open = body.open;
+  }
+  if ('notes' in body) {
+    if (typeof body.notes !== 'string') {
+      return NextResponse.json({error: 'notes must be a string'}, {status: 400});
+    }
+    trailData.notes = body.notes;
+  }
+  if (Object.keys(trailData).length === 0) {
+    return NextResponse.json({error: 'No supported trail fields provided'}, {status: 400});
+  }
+
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        yield* admin.authorize(sessionCookie, 'trails:update');
+        const db = getFirestoreClient();
+        const trailRef = db.collection('trails').doc(id);
+        yield* Effect.tryPromise({
+          try: () => trailRef.update(trailData),
+          catch: (cause) =>
+            new DatabaseError({
+              code: 'TRAIL_UPDATE_FAILED',
+              message: 'Failed to update trail',
+              cause,
+            }),
+        });
+        return {success: true};
+      }),
+    errorTags: ['UnauthorizedError', 'SessionError', 'AuthError', 'DatabaseError'],
+  });
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import DirectionsBikeIcon from '@mui/icons-material/DirectionsBike';
 import LogoutIcon from '@mui/icons-material/Logout';
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 import QrCodeScannerIcon from '@mui/icons-material/QrCodeScanner';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -22,26 +23,20 @@ import {useMutation} from '@tanstack/react-query';
 import {Effect} from 'effect';
 import {useRouter} from 'next/navigation';
 import {useEffect, useState} from 'react';
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import {Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
 
 import {MembershipManagement} from '@/src/components/admin/MembershipManagement';
+import {OrganizerManagement} from '@/src/components/admin/OrganizerManagement';
 import {ReconciliationTool} from '@/src/components/admin/ReconciliationTool';
 import {useAuth} from '@/src/components/auth/AuthProvider';
 import TrailStatus from '@/src/components/TrailStatus';
 import TrailStatusEditor from '@/src/components/TrailStatusEditor';
+import type {StaffRole} from '@/src/lib/access-control';
 import {refreshStats} from '@/src/lib/effect/client-admin';
 import type {DatabaseError, UnauthorizedError} from '@/src/lib/effect/errors';
 import type {MembershipStats} from '@/src/lib/effect/schemas';
 
-type AdminSection = 'overview' | 'members' | 'trails' | 'reconciliation';
+type AdminSection = 'overview' | 'members' | 'trails' | 'reconciliation' | 'organizers';
 
 interface DashboardStats {
   totalMembers: number;
@@ -59,11 +54,27 @@ interface DashboardStats {
   membershipGrowth?: ReadonlyArray<{readonly month: string; readonly count: number}>;
 }
 
-const sections: Array<{id: AdminSection; label: string; icon: React.ReactNode}> = [
+const allSections: Array<{
+  id: AdminSection;
+  label: string;
+  icon: React.ReactNode;
+  adminOnly?: boolean;
+}> = [
   {id: 'overview', label: 'Overview', icon: <DashboardIcon fontSize="small" />},
   {id: 'members', label: 'Members', icon: <PeopleAltIcon fontSize="small" />},
   {id: 'trails', label: 'Trail status', icon: <DirectionsBikeIcon fontSize="small" />},
-  {id: 'reconciliation', label: 'Reconciliation', icon: <SyncAltIcon fontSize="small" />},
+  {
+    id: 'reconciliation',
+    label: 'Reconciliation',
+    icon: <SyncAltIcon fontSize="small" />,
+    adminOnly: true,
+  },
+  {
+    id: 'organizers',
+    label: 'Organizers',
+    icon: <ManageAccountsIcon fontSize="small" />,
+    adminOnly: true,
+  },
 ];
 
 function AdminMark() {
@@ -85,7 +96,9 @@ function AdminMark() {
           DEC
         </Box>
       </Box>
-      <Box sx={{fontFamily: 'Anton, sans-serif', lineHeight: 1, letterSpacing: '.04em', fontSize: 13}}>
+      <Box
+        sx={{fontFamily: 'Anton, sans-serif', lineHeight: 1, letterSpacing: '.04em', fontSize: 13}}
+      >
         ADMIN
         <br />
         <Box component="span" sx={{color: '#8B8B90'}}>
@@ -108,12 +121,25 @@ function StatCard({
   dark?: boolean;
 }) {
   return (
-    <Card sx={{bgcolor: dark ? '#16130F' : 'var(--dec-surface)', color: dark ? '#fff' : 'var(--dec-ink)'}}>
+    <Card
+      sx={{
+        bgcolor: dark ? '#16130F' : 'var(--dec-surface)',
+        color: dark ? '#fff' : 'var(--dec-ink)',
+      }}
+    >
       <CardContent>
         <Typography variant="body2" sx={{color: dark ? '#B8B8BD' : 'var(--dec-muted-2)'}}>
           {label}
         </Typography>
-        <Typography sx={{fontFamily: 'Anton, sans-serif', fontSize: 34, color: accent || 'inherit', mt: .5, minHeight: 42}}>
+        <Typography
+          sx={{
+            fontFamily: 'Anton, sans-serif',
+            fontSize: 34,
+            color: accent || 'inherit',
+            mt: 0.5,
+            minHeight: 42,
+          }}
+        >
           {value ?? ''}
         </Typography>
       </CardContent>
@@ -126,7 +152,7 @@ export default function DashboardPage() {
   const router = useRouter();
   const {user, loading, signOut} = useAuth();
   const [authError, setAuthError] = useState<string | null>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
+  const [staffRole, setStaffRole] = useState<StaffRole | null>(null);
   const [checkingAdmin, setCheckingAdmin] = useState(true);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [dashboardStats, setDashboardStats] = useState<DashboardStats>({
@@ -171,13 +197,13 @@ export default function DashboardPage() {
           return;
         }
 
-        if (!data.isAdmin) {
+        if (data.role !== 'admin' && data.role !== 'organizer') {
           setAuthError('You are not authorized to access this dashboard.');
           signOut().then(() => router.replace('/login'));
           return;
         }
 
-        setIsAdmin(true);
+        setStaffRole(data.role);
       } catch (error) {
         console.error('Failed to check admin status:', error);
         setAuthError('Failed to verify admin access.');
@@ -218,8 +244,8 @@ export default function DashboardPage() {
       }
     };
 
-    if (isAdmin) fetchStats();
-  }, [isAdmin]);
+    if (staffRole) fetchStats();
+  }, [staffRole]);
 
   const handleLogout = async () => {
     try {
@@ -244,7 +270,7 @@ export default function DashboardPage() {
     );
   }
 
-  if (authError || !isAdmin) {
+  if (authError || !staffRole) {
     return (
       <Container>
         <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 8}}>
@@ -258,10 +284,14 @@ export default function DashboardPage() {
     );
   }
 
+  const sections = allSections.filter((item) => !item.adminOnly || staffRole === 'admin');
   const sectionTitle = sections.find((item) => item.id === section)?.label || 'Overview';
 
   return (
-    <Box className="dec-admin-page" sx={{display: 'flex', minHeight: 'calc(100vh - 76px)', mt: '-76px', pt: '76px'}}>
+    <Box
+      className="dec-admin-page"
+      sx={{display: 'flex', minHeight: 'calc(100vh - 76px)', mt: '-76px', pt: '76px'}}
+    >
       <Box
         component="aside"
         sx={{
@@ -279,10 +309,19 @@ export default function DashboardPage() {
         }}
       >
         <AdminMark />
-        <Typography sx={{px: 3, pb: 1, fontSize: 11, fontWeight: 800, letterSpacing: '.1em', color: '#6A6A6F'}}>
+        <Typography
+          sx={{
+            px: 3,
+            pb: 1,
+            fontSize: 11,
+            fontWeight: 800,
+            letterSpacing: '.1em',
+            color: '#6A6A6F',
+          }}
+        >
           MANAGE
         </Typography>
-        <Box component="nav" sx={{display: 'flex', flexDirection: 'column', gap: .25, px: 1.5}}>
+        <Box component="nav" sx={{display: 'flex', flexDirection: 'column', gap: 0.25, px: 1.5}}>
           {sections.map((item) => (
             <Button
               key={item.id}
@@ -300,21 +339,45 @@ export default function DashboardPage() {
               {item.label}
             </Button>
           ))}
-          <Button disabled startIcon={<QrCodeScannerIcon fontSize="small" />} sx={{justifyContent: 'flex-start', px: 1.5}}>
+          <Button
+            disabled
+            startIcon={<QrCodeScannerIcon fontSize="small" />}
+            sx={{justifyContent: 'flex-start', px: 1.5}}
+          >
             Verify (QR) · SOON
           </Button>
         </Box>
 
         <Box sx={{mt: 'auto', px: 1.5}}>
-          <Box sx={{borderTop: '1px solid rgba(255,255,255,.1)', pt: 2, display: 'flex', gap: 1.25, alignItems: 'center'}}>
-            <Box sx={{width: 34, height: 34, borderRadius: '50%', bgcolor: '#F20E02', display: 'grid', placeItems: 'center', fontWeight: 800}}>
+          <Box
+            sx={{
+              borderTop: '1px solid rgba(255,255,255,.1)',
+              pt: 2,
+              display: 'flex',
+              gap: 1.25,
+              alignItems: 'center',
+            }}
+          >
+            <Box
+              sx={{
+                width: 34,
+                height: 34,
+                borderRadius: '50%',
+                bgcolor: '#F20E02',
+                display: 'grid',
+                placeItems: 'center',
+                fontWeight: 800,
+              }}
+            >
               {(user?.displayName || user?.email || 'A').slice(0, 1).toUpperCase()}
             </Box>
             <Box sx={{minWidth: 0, flex: 1}}>
               <Typography noWrap sx={{fontSize: 13, fontWeight: 800}}>
                 {user?.displayName || user?.email?.split('@')[0] || 'Admin'}
               </Typography>
-              <Typography sx={{fontSize: 11, color: '#8B8B90'}}>Administrator</Typography>
+              <Typography sx={{fontSize: 11, color: '#8B8B90'}}>
+                {staffRole === 'admin' ? 'Administrator' : 'Organizer'}
+              </Typography>
             </Box>
             <Button
               onClick={handleLogout}
@@ -355,7 +418,9 @@ export default function DashboardPage() {
           </Box>
           <Button
             variant="outlined"
-            startIcon={refreshStatsMutation.isPending ? <CircularProgress size={18} /> : <RefreshIcon />}
+            startIcon={
+              refreshStatsMutation.isPending ? <CircularProgress size={18} /> : <RefreshIcon />
+            }
             onClick={() => refreshStatsMutation.mutate()}
             disabled={refreshStatsMutation.isPending}
           >
@@ -363,7 +428,15 @@ export default function DashboardPage() {
           </Button>
         </Paper>
 
-        <Box sx={{display: {xs: 'flex', md: 'none'}, gap: 1, overflowX: 'auto', p: 2, borderBottom: '1px solid var(--dec-border)'}}>
+        <Box
+          sx={{
+            display: {xs: 'flex', md: 'none'},
+            gap: 1,
+            overflowX: 'auto',
+            p: 2,
+            borderBottom: '1px solid var(--dec-border)',
+          }}
+        >
           {sections.map((item) => (
             <Button
               key={item.id}
@@ -385,20 +458,36 @@ export default function DashboardPage() {
 
           {section === 'overview' && (
             <Box sx={{display: 'grid', gap: 3}}>
-              <Box sx={{display: 'grid', gridTemplateColumns: {xs: '1fr 1fr', lg: 'repeat(5, minmax(0, 1fr))'}, gap: 2}}>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: {xs: '1fr 1fr', lg: 'repeat(5, minmax(0, 1fr))'},
+                  gap: 2,
+                }}
+              >
                 <StatCard label="Total members" value={dashboardStats.totalMembers} />
                 <StatCard label="Active" value={dashboardStats.activeMembers} accent="#1F8A5B" />
-                <StatCard label="Expiring (30d)" value={dashboardStats.expiringSoonMembers ?? ''} accent="#C7801A" />
+                <StatCard
+                  label="Expiring (30d)"
+                  value={dashboardStats.expiringSoonMembers ?? ''}
+                  accent="#C7801A"
+                />
                 <StatCard label="New this month" value={dashboardStats.newMembersThisMonth ?? ''} />
                 <StatCard
                   label="Annual revenue"
-                  value={dashboardStats.yearlyRevenue != null ? `$${dashboardStats.yearlyRevenue.toLocaleString()}` : ''}
+                  value={
+                    dashboardStats.yearlyRevenue != null
+                      ? `$${dashboardStats.yearlyRevenue.toLocaleString()}`
+                      : ''
+                  }
                   accent="#7CF3A0"
                   dark
                 />
               </Box>
 
-              <Box sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', lg: '1.5fr 1fr'}, gap: 3}}>
+              <Box
+                sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', lg: '1.5fr 1fr'}, gap: 3}}
+              >
                 <Paper className="dec-card" sx={{p: 3}}>
                   <Typography variant="h4" component="h2" sx={{mb: 3}}>
                     Membership growth
@@ -442,8 +531,18 @@ export default function DashboardPage() {
                       </ResponsiveContainer>
                     </Box>
                   ) : (
-                    <Box sx={{minHeight: 220, display: 'grid', placeItems: 'center', border: '1px dashed var(--dec-border)', borderRadius: 2}}>
-                      <Typography color="text.secondary">No membership growth data available.</Typography>
+                    <Box
+                      sx={{
+                        minHeight: 220,
+                        display: 'grid',
+                        placeItems: 'center',
+                        border: '1px dashed var(--dec-border)',
+                        borderRadius: 2,
+                      }}
+                    >
+                      <Typography color="text.secondary">
+                        No membership growth data available.
+                      </Typography>
                     </Box>
                   )}
                 </Paper>
@@ -459,9 +558,17 @@ export default function DashboardPage() {
                       Quick actions
                     </Typography>
                     <Box sx={{display: 'grid', gap: 1.5}}>
-                      <Button variant="contained" onClick={() => setSection('members')}>Manage members</Button>
-                      <Button variant="outlined" onClick={() => setSection('trails')}>Update trail status</Button>
-                      <Button variant="outlined" onClick={() => setSection('reconciliation')}>Run reconciliation</Button>
+                      <Button variant="contained" onClick={() => setSection('members')}>
+                        Manage members
+                      </Button>
+                      <Button variant="outlined" onClick={() => setSection('trails')}>
+                        Update trail status
+                      </Button>
+                      {staffRole === 'admin' && (
+                        <Button variant="outlined" onClick={() => setSection('reconciliation')}>
+                          Run reconciliation
+                        </Button>
+                      )}
                     </Box>
                   </Paper>
                 </Box>
@@ -469,7 +576,7 @@ export default function DashboardPage() {
             </Box>
           )}
 
-          {section === 'members' && <MembershipManagement />}
+          {section === 'members' && <MembershipManagement role={staffRole} />}
 
           {section === 'trails' && (
             <Box sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', lg: '1fr 1fr'}, gap: 3}}>
@@ -485,7 +592,9 @@ export default function DashboardPage() {
             </Box>
           )}
 
-          {section === 'reconciliation' && <ReconciliationTool />}
+          {section === 'reconciliation' && staffRole === 'admin' && <ReconciliationTool />}
+
+          {section === 'organizers' && staffRole === 'admin' && <OrganizerManagement />}
         </Box>
       </Box>
     </Box>

--- a/app/member/layout.tsx
+++ b/app/member/layout.tsx
@@ -1,6 +1,7 @@
 import {redirect} from 'next/navigation';
 
 import {verifySession} from '@/src/actions/auth';
+import {isPrimaryAdminEmail} from '@/src/lib/primary-admin';
 
 export default async function MemberLayout({children}: {children: React.ReactNode}) {
   const session = await verifySession();
@@ -9,13 +10,7 @@ export default async function MemberLayout({children}: {children: React.ReactNod
     redirect('/login');
   }
 
-  // Check if user is admin and redirect to dashboard
-  const adminEmail = (process.env.NEXT_PUBLIC_ALLOWED_EMAIL || 'info@downeastcyclists.com')
-    .toLowerCase()
-    .trim();
-  const userEmail = (session.email || '').toLowerCase().trim();
-
-  if (userEmail === adminEmail) {
+  if (isPrimaryAdminEmail(session.email)) {
     redirect('/dashboard');
   }
 

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -14,7 +14,11 @@ import {Effect} from 'effect';
 import {useRouter} from 'next/navigation';
 import {useEffect, useState} from 'react';
 
-import {isValidSignInLink, completeMagicLinkSignIn} from '@/src/lib/effect/client-auth';
+import {
+  completeMagicLinkSignIn,
+  getCurrentAccessRole,
+  isValidSignInLink,
+} from '@/src/lib/effect/client-auth';
 import type {AuthError} from '@/src/lib/effect/errors';
 
 export default function VerifyPage() {
@@ -26,17 +30,9 @@ export default function VerifyPage() {
   // Mutation for completing sign-in
   const verifyMutation = useMutation<unknown, AuthError, string>({
     mutationFn: (email) => Effect.runPromise(completeMagicLinkSignIn(email, window.location.href)),
-    onSuccess: (_, email) => {
-      // Check if user is admin - normalize email comparison
-      const adminEmail = (process.env.NEXT_PUBLIC_ALLOWED_EMAIL || 'info@downeastcyclists.com')
-        .toLowerCase()
-        .trim();
-      const userEmail = email.toLowerCase().trim();
-      const isAdmin = userEmail === adminEmail;
-
-      // Use window.location for a hard redirect to ensure it works
-      const redirectUrl = isAdmin ? '/dashboard' : '/member';
-      window.location.href = redirectUrl;
+    onSuccess: async () => {
+      const role = await Effect.runPromise(getCurrentAccessRole());
+      window.location.href = role === 'member' ? '/member' : '/dashboard';
     },
     onError: () => {
       // Clear the invalid link state and show error
@@ -134,57 +130,60 @@ export default function VerifyPage() {
   if (needsEmail) {
     return (
       <main className="dec-page">
-      <Container maxWidth="xs">
-        <Box
-          className="dec-card"
-          sx={{
-            marginTop: 8,
-            mb: 8,
-            p: 4,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-          }}
-        >
-          <Typography variant="overline" sx={{color: '#F20E02', fontWeight: 800, letterSpacing: '.1em'}}>
-            MAGIC LINK
-          </Typography>
-          <Typography component="h1" variant="h1" sx={{fontSize: 54}} gutterBottom>
-            Confirm your email
-          </Typography>
-          <Typography color="text.secondary" textAlign="center" sx={{mb: 2}}>
-            Please enter the email address you used to request the sign-in link.
-          </Typography>
-
-          {verifyMutation.error && (
-            <Alert severity="error" sx={{width: '100%', mb: 2}}>
-              {verifyMutation.error.message}
-            </Alert>
-          )}
-
-          <Box component="form" onSubmit={handleEmailSubmit} sx={{width: '100%'}}>
-            <TextField
-              fullWidth
-              label="Email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              margin="normal"
-              required
-              disabled={verifyMutation.isPending}
-            />
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              sx={{mt: 2}}
-              disabled={verifyMutation.isPending}
+        <Container maxWidth="xs">
+          <Box
+            className="dec-card"
+            sx={{
+              marginTop: 8,
+              mb: 8,
+              p: 4,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <Typography
+              variant="overline"
+              sx={{color: '#F20E02', fontWeight: 800, letterSpacing: '.1em'}}
             >
-              {verifyMutation.isPending ? 'Verifying...' : 'Continue'}
-            </Button>
+              MAGIC LINK
+            </Typography>
+            <Typography component="h1" variant="h1" sx={{fontSize: 54}} gutterBottom>
+              Confirm your email
+            </Typography>
+            <Typography color="text.secondary" textAlign="center" sx={{mb: 2}}>
+              Please enter the email address you used to request the sign-in link.
+            </Typography>
+
+            {verifyMutation.error && (
+              <Alert severity="error" sx={{width: '100%', mb: 2}}>
+                {verifyMutation.error.message}
+              </Alert>
+            )}
+
+            <Box component="form" onSubmit={handleEmailSubmit} sx={{width: '100%'}}>
+              <TextField
+                fullWidth
+                label="Email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                margin="normal"
+                required
+                disabled={verifyMutation.isPending}
+              />
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                sx={{mt: 2}}
+                disabled={verifyMutation.isPending}
+              >
+                {verifyMutation.isPending ? 'Verifying...' : 'Continue'}
+              </Button>
+            </Box>
           </Box>
-        </Box>
-      </Container>
+        </Container>
       </main>
     );
   }

--- a/drizzle/0002_graceful_timeslip.sql
+++ b/drizzle/0002_graceful_timeslip.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "is_organizer" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1039 @@
+{
+  "id": "1e753538-9c55-43ed-bf42-c7b7f6b5b427",
+  "prevId": "7a5effbe-4c02-47f6-b47c-d18dbbdb6f1f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_email": {
+          "name": "performed_by_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup_events": {
+      "name": "meetup_events",
+      "schema": "",
+      "columns": {
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_events_start_date_idx": {
+          "name": "meetup_events_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_cards": {
+      "name": "membership_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_number": {
+          "name": "membership_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_name": {
+          "name": "member_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "plan_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qr_code_data": {
+          "name": "qr_code_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_cards_user_id_idx": {
+          "name": "membership_cards_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "membership_cards_membership_id_idx": {
+          "name": "membership_cards_membership_id_idx",
+          "columns": [
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_cards_user_id_users_id_fk": {
+          "name": "membership_cards_user_id_users_id_fk",
+          "tableFrom": "membership_cards",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_cards_membership_id_memberships_id_fk": {
+          "name": "membership_cards_membership_id_memberships_id_fk",
+          "tableFrom": "membership_cards",
+          "tableTo": "memberships",
+          "columnsFrom": ["membership_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_cards_membership_number_unique": {
+          "name": "membership_cards_membership_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["membership_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_counters": {
+      "name": "membership_counters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_number": {
+          "name": "last_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_counters_year_idx": {
+          "name": "membership_counters_year_idx",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_plans": {
+      "name": "membership_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "plan_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_plans_stripe_price_idx": {
+          "name": "membership_plans_stripe_price_idx",
+          "columns": [
+            {
+              "expression": "stripe_price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_stats": {
+      "name": "membership_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'memberships'"
+        },
+        "total_members": {
+          "name": "total_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_members": {
+          "name": "active_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expired_members": {
+          "name": "expired_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "canceled_members": {
+          "name": "canceled_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "individual_count": {
+          "name": "individual_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "family_count": {
+          "name": "family_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_revenue": {
+          "name": "monthly_revenue",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "yearly_revenue": {
+          "name": "yearly_revenue",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "plan_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incomplete'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_renew": {
+          "name": "auto_renew",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_user_id_idx": {
+          "name": "memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_stripe_sub_idx": {
+          "name": "memberships_stripe_sub_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_status_end_date_idx": {
+          "name": "memberships_status_end_date_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_status_idx": {
+          "name": "memberships_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street": {
+          "name": "address_street",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_stripe_customer_idx": {
+          "name": "users_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["firebase_uid"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_events_type_idx": {
+          "name": "webhook_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_idx": {
+          "name": "webhook_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "MEMBER_CREATED",
+        "MEMBER_UPDATED",
+        "MEMBER_DELETED",
+        "MEMBERSHIP_EXTENDED",
+        "MEMBERSHIP_PAUSED",
+        "EMAIL_CHANGED",
+        "STRIPE_SYNCED",
+        "REFUND_ISSUED",
+        "BULK_IMPORT",
+        "ADMIN_ROLE_CHANGE",
+        "MEMBERSHIP_ADJUSTMENT",
+        "RECONCILIATION"
+      ]
+    },
+    "public.membership_status": {
+      "name": "membership_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "past_due",
+        "canceled",
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "unpaid",
+        "deleted",
+        "complimentary",
+        "legacy"
+      ]
+    },
+    "public.plan_interval": {
+      "name": "plan_interval",
+      "schema": "public",
+      "values": ["year", "month"]
+    },
+    "public.plan_type": {
+      "name": "plan_type",
+      "schema": "public",
+      "values": ["individual", "family"]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783980440012,
       "tag": "0001_supreme_leech",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784991424003,
+      "tag": "0002_graceful_timeslip",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/layers/test-layers.ts
+++ b/src/__tests__/layers/test-layers.ts
@@ -220,8 +220,10 @@ export const createTestPortalService = (
 export const createTestAdminService = (
   overrides: Partial<AdminServiceType> = {},
 ): AdminServiceType => ({
+  getAccess: vi.fn(() => Effect.die('Not mocked')) as unknown as AdminServiceType['getAccess'],
+  authorize: vi.fn(() => Effect.die('Not mocked')) as unknown as AdminServiceType['authorize'],
   verifyAdmin: vi.fn(() => Effect.die('Not mocked')) as unknown as AdminServiceType['verifyAdmin'],
-  setAdminRole: vi.fn(() => Effect.void),
+  setOrganizerRole: vi.fn(() => Effect.void),
   searchMembers: vi.fn(() => Effect.succeed({members: [], total: 0})),
   getMember: vi.fn(() =>
     Effect.fail(new NotFoundError({resource: 'user', id: ''})),

--- a/src/__tests__/lib/access-control.test.ts
+++ b/src/__tests__/lib/access-control.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from 'vitest';
+
+import {
+  getDashboardCapabilities,
+  hasCurrentMembership,
+  hasDashboardCapability,
+} from '@/src/lib/access-control';
+
+describe('dashboard capabilities', () => {
+  it('allows organizers to use reporting and trail tools', () => {
+    expect(hasDashboardCapability('organizer', 'members:read')).toBe(true);
+    expect(hasDashboardCapability('organizer', 'members:export')).toBe(true);
+    expect(hasDashboardCapability('organizer', 'members:password-reset')).toBe(true);
+    expect(hasDashboardCapability('organizer', 'stats:refresh')).toBe(true);
+    expect(hasDashboardCapability('organizer', 'trails:update')).toBe(true);
+  });
+
+  it('denies organizers admin-only capabilities', () => {
+    expect(hasDashboardCapability('organizer', 'members:write')).toBe(false);
+    expect(hasDashboardCapability('organizer', 'members:payments')).toBe(false);
+    expect(hasDashboardCapability('organizer', 'members:refund')).toBe(false);
+    expect(hasDashboardCapability('organizer', 'members:import')).toBe(false);
+    expect(hasDashboardCapability('organizer', 'reconciliation:run')).toBe(false);
+    expect(hasDashboardCapability('organizer', 'organizers:manage')).toBe(false);
+  });
+
+  it('gives members no dashboard capabilities', () => {
+    expect(getDashboardCapabilities('member')).toEqual([]);
+  });
+
+  it('gives the administrator every organizer and admin capability', () => {
+    expect(hasDashboardCapability('admin', 'members:read')).toBe(true);
+    expect(hasDashboardCapability('admin', 'members:write')).toBe(true);
+    expect(hasDashboardCapability('admin', 'reconciliation:run')).toBe(true);
+    expect(hasDashboardCapability('admin', 'organizers:manage')).toBe(true);
+  });
+
+  it('requires a paid or trialing membership with a current end date', () => {
+    const now = new Date('2026-07-25T12:00:00.000Z');
+
+    expect(hasCurrentMembership({status: 'active', endDate: '2026-07-26T12:00:00.000Z'}, now)).toBe(
+      true,
+    );
+    expect(
+      hasCurrentMembership({status: 'past_due', endDate: '2026-07-26T12:00:00.000Z'}, now),
+    ).toBe(false);
+    expect(hasCurrentMembership({status: 'active', endDate: '2026-07-24T12:00:00.000Z'}, now)).toBe(
+      false,
+    );
+  });
+});

--- a/src/__tests__/services/admin-access.service.test.ts
+++ b/src/__tests__/services/admin-access.service.test.ts
@@ -1,0 +1,220 @@
+import {Effect, Layer} from 'effect';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {AdminService, AdminServiceLive} from '@/src/lib/effect/admin.service';
+import {MembershipCardService} from '@/src/lib/effect/card.service';
+import {StatsService} from '@/src/lib/effect/stats.service';
+
+import {
+  createTestAuthService,
+  createTestCardService,
+  createTestDatabaseService,
+  createTestEmailService,
+  createTestStripeService,
+  TestAuthLayer,
+  TestDatabaseLayer,
+  TestEmailLayer,
+  TestStripeLayer,
+} from '../layers/test-layers';
+import {createMockMembershipDocument, createMockUserDocument} from '../mocks/database.mock';
+
+const stats = {
+  totalMembers: 0,
+  activeMembers: 0,
+  expiredMembers: 0,
+  canceledMembers: 0,
+  individualCount: 0,
+  familyCount: 0,
+  monthlyRevenue: 0,
+  yearlyRevenue: 0,
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function makeLayer(
+  authService: ReturnType<typeof createTestAuthService>,
+  databaseService: ReturnType<typeof createTestDatabaseService>,
+) {
+  const statsService = StatsService.of({
+    getStats: () => Effect.succeed(stats),
+    refreshStats: () => Effect.succeed(stats),
+    incrementStat: () => Effect.void,
+    decrementStat: () => Effect.void,
+  });
+
+  return Layer.mergeAll(
+    TestAuthLayer(authService),
+    TestDatabaseLayer(databaseService),
+    TestStripeLayer(createTestStripeService()),
+    Layer.succeed(MembershipCardService, createTestCardService()),
+    Layer.succeed(StatsService, statsService),
+    TestEmailLayer(createTestEmailService()),
+  );
+}
+
+function runWithAdminService<A, E>(
+  program: Effect.Effect<A, E, AdminService>,
+  authService: ReturnType<typeof createTestAuthService>,
+  databaseService: ReturnType<typeof createTestDatabaseService>,
+) {
+  return Effect.runPromise(
+    program.pipe(
+      Effect.provide(AdminServiceLive),
+      Effect.provide(makeLayer(authService, databaseService)),
+    ),
+  );
+}
+
+describe('AdminService access control', () => {
+  beforeEach(() => {
+    process.env.ADMIN_EMAIL = 'admin@example.com';
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_EMAIL;
+  });
+
+  it('recognizes only the configured claimed account as administrator', async () => {
+    const getUser = vi.fn(() => Effect.succeed(null));
+    const authService = createTestAuthService({
+      verifyAdminClaim: () =>
+        Effect.succeed({uid: 'admin_uid', email: 'admin@example.com', isAdmin: true}),
+    });
+    const databaseService = createTestDatabaseService({getUser});
+
+    const access = await runWithAdminService(
+      Effect.flatMap(AdminService, (service) => service.getAccess('session')),
+      authService,
+      databaseService,
+    );
+
+    expect(access.role).toBe('admin');
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a different claimed account as administrator', async () => {
+    const authService = createTestAuthService({
+      verifyAdminClaim: () =>
+        Effect.succeed({uid: 'other_uid', email: 'other@example.com', isAdmin: true}),
+    });
+    const databaseService = createTestDatabaseService({
+      getUser: () => Effect.succeed(createMockUserDocument({id: 'other_uid', isOrganizer: false})),
+    });
+
+    const access = await runWithAdminService(
+      Effect.flatMap(AdminService, (service) => service.getAccess('session')),
+      authService,
+      databaseService,
+    );
+
+    expect(access.role).toBe('member');
+  });
+
+  it('allows organizers reporting access but denies reconciliation', async () => {
+    const authService = createTestAuthService({
+      verifyAdminClaim: () =>
+        Effect.succeed({uid: 'organizer_uid', email: 'org@example.com', isAdmin: false}),
+    });
+    const databaseService = createTestDatabaseService({
+      getUser: () =>
+        Effect.succeed(createMockUserDocument({id: 'organizer_uid', isOrganizer: true})),
+      getActiveMembership: () => Effect.succeed(createMockMembershipDocument()),
+    });
+
+    const allowed = await runWithAdminService(
+      Effect.flatMap(AdminService, (service) => service.authorize('session', 'members:read')),
+      authService,
+      databaseService,
+    );
+    const denied = await Effect.runPromiseExit(
+      Effect.flatMap(AdminService, (service) =>
+        service.authorize('session', 'reconciliation:run'),
+      ).pipe(
+        Effect.provide(AdminServiceLive),
+        Effect.provide(makeLayer(authService, databaseService)),
+      ),
+    );
+
+    expect(allowed.role).toBe('organizer');
+    expect(denied._tag).toBe('Failure');
+  });
+
+  it('removes dashboard access when an organizer membership is no longer current', async () => {
+    const authService = createTestAuthService({
+      verifyAdminClaim: () =>
+        Effect.succeed({uid: 'organizer_uid', email: 'org@example.com', isAdmin: false}),
+    });
+    const databaseService = createTestDatabaseService({
+      getUser: () =>
+        Effect.succeed(createMockUserDocument({id: 'organizer_uid', isOrganizer: true})),
+      getActiveMembership: () => Effect.succeed(createMockMembershipDocument({status: 'past_due'})),
+    });
+
+    const access = await runWithAdminService(
+      Effect.flatMap(AdminService, (service) => service.getAccess('session')),
+      authService,
+      databaseService,
+    );
+
+    expect(access.role).toBe('member');
+  });
+
+  it('lets the administrator grant organizer access and records the change', async () => {
+    const updateUser = vi.fn(() => Effect.void);
+    const logAuditEntry = vi.fn(() => Effect.void);
+    const authService = createTestAuthService({
+      verifyAdminClaim: () =>
+        Effect.succeed({uid: 'admin_uid', email: 'admin@example.com', isAdmin: true}),
+    });
+    const databaseService = createTestDatabaseService({
+      getUser: () => Effect.succeed(createMockUserDocument({id: 'member_uid'})),
+      getActiveMembership: () => Effect.succeed(createMockMembershipDocument()),
+      updateUser,
+      logAuditEntry,
+    });
+
+    await runWithAdminService(
+      Effect.flatMap(AdminService, (service) =>
+        service.setOrganizerRole('session', 'member_uid', true),
+      ),
+      authService,
+      databaseService,
+    );
+
+    expect(updateUser).toHaveBeenCalledWith('member_uid', {isOrganizer: true});
+    expect(logAuditEntry).toHaveBeenCalledWith(
+      'member_uid',
+      'ADMIN_ROLE_CHANGE',
+      expect.objectContaining({
+        performedBy: 'admin_uid',
+        performedByEmail: 'admin@example.com',
+        role: 'organizer',
+        newValue: true,
+      }),
+    );
+  });
+
+  it('rejects organizer grants for members without a current membership', async () => {
+    const updateUser = vi.fn(() => Effect.void);
+    const authService = createTestAuthService({
+      verifyAdminClaim: () =>
+        Effect.succeed({uid: 'admin_uid', email: 'admin@example.com', isAdmin: true}),
+    });
+    const databaseService = createTestDatabaseService({
+      getUser: () => Effect.succeed(createMockUserDocument({id: 'member_uid'})),
+      getActiveMembership: () => Effect.succeed(null),
+      updateUser,
+    });
+
+    const result = await Effect.runPromiseExit(
+      Effect.flatMap(AdminService, (service) =>
+        service.setOrganizerRole('session', 'member_uid', true),
+      ).pipe(
+        Effect.provide(AdminServiceLive),
+        Effect.provide(makeLayer(authService, databaseService)),
+      ),
+    );
+
+    expect(result._tag).toBe('Failure');
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/admin/MemberTable.tsx
+++ b/src/components/admin/MemberTable.tsx
@@ -37,7 +37,7 @@ interface MemberTableProps {
   pageSize: number;
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
-  onEditMember: (member: MemberWithMembership) => void;
+  onEditMember?: (member: MemberWithMembership) => void;
   onDeleteMember?: (member: MemberWithMembership) => void;
   onViewAudit?: (member: MemberWithMembership) => void;
   onViewPayments?: (member: MemberWithMembership) => void;
@@ -117,15 +117,17 @@ export function MemberTable({
                   <TableCell>{formattedEndDate}</TableCell>
                   <TableCell align="center">
                     <Box sx={{display: 'flex', gap: 0.5, justifyContent: 'center'}}>
-                      <Tooltip title="Edit">
-                        <IconButton
-                          size="small"
-                          color="primary"
-                          onClick={() => onEditMember(member)}
-                        >
-                          <Edit fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
+                      {onEditMember && (
+                        <Tooltip title="Edit">
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            onClick={() => onEditMember(member)}
+                          >
+                            <Edit fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                       {onViewAudit && (
                         <Tooltip title="View Audit Log">
                           <IconButton size="small" onClick={() => onViewAudit(member)}>

--- a/src/components/admin/MembershipManagement.tsx
+++ b/src/components/admin/MembershipManagement.tsx
@@ -19,6 +19,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {Effect} from 'effect';
 import {useState} from 'react';
 
+import type {StaffRole} from '@/src/lib/access-control';
 import {refreshStats, getStats, getMembers, sendPasswordReset} from '@/src/lib/effect/client-admin';
 import type {
   AdminError,
@@ -38,7 +39,8 @@ import {MemberTable} from './MemberTable';
 import {PaymentHistoryPanel} from './PaymentHistoryPanel';
 import {StatsCards} from './StatsCards';
 
-export function MembershipManagement() {
+export function MembershipManagement({role}: {role: StaffRole}) {
+  const isAdmin = role === 'admin';
   const queryClient = useQueryClient();
   const [exporting, setExporting] = useState(false);
 
@@ -168,7 +170,16 @@ export function MembershipManagement() {
     <Box sx={{display: 'flex', flexDirection: 'column', gap: 3}}>
       {/* Stats Section */}
       <Box>
-        <Box sx={{display: 'flex', justifyContent: 'space-between', alignItems: {xs: 'stretch', lg: 'center'}, mb: 2, gap: 2, flexDirection: {xs: 'column', lg: 'row'}}}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: {xs: 'stretch', lg: 'center'},
+            mb: 2,
+            gap: 2,
+            flexDirection: {xs: 'column', lg: 'row'},
+          }}
+        >
           <Typography variant="h5" component="h2">
             Membership Statistics
           </Typography>
@@ -192,28 +203,48 @@ export function MembershipManagement() {
 
       {/* Members Section */}
       <Box>
-        <Box sx={{display: 'flex', justifyContent: 'space-between', alignItems: {xs: 'stretch', lg: 'center'}, mb: 2, gap: 2, flexDirection: {xs: 'column', lg: 'row'}}}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: {xs: 'stretch', lg: 'center'},
+            mb: 2,
+            gap: 2,
+            flexDirection: {xs: 'column', lg: 'row'},
+          }}
+        >
           <Typography variant="h5" component="h2">
             Members
           </Typography>
-          <Box sx={{display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: {xs: 'flex-start', lg: 'flex-end'}}}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={() => setCreateModalOpen(true)}
-              startIcon={<Add />}
-              sx={{order: {xs: 1, lg: 5}}}
-            >
-              Create Member
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={() => setBulkImportModalOpen(true)}
-              startIcon={<Upload />}
-              sx={{order: {xs: 2, lg: 1}}}
-            >
-              Bulk Import
-            </Button>
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 1,
+              flexWrap: 'wrap',
+              justifyContent: {xs: 'flex-start', lg: 'flex-end'},
+            }}
+          >
+            {isAdmin && (
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={() => setCreateModalOpen(true)}
+                startIcon={<Add />}
+                sx={{order: {xs: 1, lg: 5}}}
+              >
+                Create Member
+              </Button>
+            )}
+            {isAdmin && (
+              <Button
+                variant="outlined"
+                onClick={() => setBulkImportModalOpen(true)}
+                startIcon={<Upload />}
+                sx={{order: {xs: 2, lg: 1}}}
+              >
+                Bulk Import
+              </Button>
+            )}
             <Button
               variant="outlined"
               onClick={() => setExpiringReportOpen(true)}
@@ -231,15 +262,17 @@ export function MembershipManagement() {
             >
               {exporting ? 'Exporting...' : 'Export CSV'}
             </Button>
-            <Button
-              variant="contained"
-              color="success"
-              onClick={() => handleExport('json')}
-              disabled={exporting}
-              sx={{order: {xs: 5, lg: 4}}}
-            >
-              {exporting ? 'Exporting...' : 'Export JSON'}
-            </Button>
+            {isAdmin && (
+              <Button
+                variant="contained"
+                color="success"
+                onClick={() => handleExport('json')}
+                disabled={exporting}
+                sx={{order: {xs: 5, lg: 4}}}
+              >
+                {exporting ? 'Exporting...' : 'Export JSON'}
+              </Button>
+            )}
           </Box>
         </Box>
 
@@ -353,10 +386,10 @@ export function MembershipManagement() {
               setPageSize(newSize);
               setPage(1);
             }}
-            onEditMember={(member) => setEditingMember(member)}
-            onDeleteMember={(member) => setDeletingMember(member)}
+            onEditMember={isAdmin ? (member) => setEditingMember(member) : undefined}
+            onDeleteMember={isAdmin ? (member) => setDeletingMember(member) : undefined}
             onViewAudit={(member) => setAuditMember(member)}
-            onViewPayments={(member) => setPaymentHistoryMember(member)}
+            onViewPayments={isAdmin ? (member) => setPaymentHistoryMember(member) : undefined}
             onSendPasswordReset={(member) =>
               member.user?.id && passwordResetMutation.mutate(member.user.id)
             }
@@ -365,26 +398,34 @@ export function MembershipManagement() {
       </Box>
 
       {/* Modals */}
-      <CreateMemberModal open={createModalOpen} onClose={() => setCreateModalOpen(false)} />
+      {isAdmin && (
+        <CreateMemberModal open={createModalOpen} onClose={() => setCreateModalOpen(false)} />
+      )}
 
-      <BulkImportModal open={bulkImportModalOpen} onClose={() => setBulkImportModalOpen(false)} />
+      {isAdmin && (
+        <BulkImportModal open={bulkImportModalOpen} onClose={() => setBulkImportModalOpen(false)} />
+      )}
 
       <ExpiringMembersReport
         open={expiringReportOpen}
         onClose={() => setExpiringReportOpen(false)}
       />
 
-      <EditMemberModal
-        open={!!editingMember}
-        member={editingMember}
-        onClose={() => setEditingMember(null)}
-      />
+      {isAdmin && (
+        <EditMemberModal
+          open={!!editingMember}
+          member={editingMember}
+          onClose={() => setEditingMember(null)}
+        />
+      )}
 
-      <DeleteMemberDialog
-        open={!!deletingMember}
-        member={deletingMember}
-        onClose={() => setDeletingMember(null)}
-      />
+      {isAdmin && (
+        <DeleteMemberDialog
+          open={!!deletingMember}
+          member={deletingMember}
+          onClose={() => setDeletingMember(null)}
+        />
+      )}
 
       <MemberAuditLog
         open={!!auditMember}
@@ -393,12 +434,14 @@ export function MembershipManagement() {
         onClose={() => setAuditMember(null)}
       />
 
-      <PaymentHistoryPanel
-        open={!!paymentHistoryMember}
-        userId={paymentHistoryMember?.user?.id || null}
-        memberName={paymentHistoryMember?.user?.name || paymentHistoryMember?.user?.email}
-        onClose={() => setPaymentHistoryMember(null)}
-      />
+      {isAdmin && (
+        <PaymentHistoryPanel
+          open={!!paymentHistoryMember}
+          userId={paymentHistoryMember?.user?.id || null}
+          memberName={paymentHistoryMember?.user?.name || paymentHistoryMember?.user?.email}
+          onClose={() => setPaymentHistoryMember(null)}
+        />
+      )}
     </Box>
   );
 }

--- a/src/components/admin/OrganizerManagement.tsx
+++ b/src/components/admin/OrganizerManagement.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {Effect} from 'effect';
+import {useState} from 'react';
+
+import {hasCurrentMembership} from '@/src/lib/access-control';
+import {getMembers, type GetMembersResponse} from '@/src/lib/effect/client-admin';
+import type {MemberWithMembership} from '@/src/lib/effect/schemas';
+
+interface OrganizerUpdate {
+  readonly userId: string;
+  readonly isOrganizer: boolean;
+}
+
+type RoleFilter = 'all' | 'organizer' | 'member';
+
+async function updateOrganizerRole({userId, isOrganizer}: OrganizerUpdate): Promise<void> {
+  const response = await fetch(`/api/admin/organizers/${userId}`, {
+    method: 'PATCH',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({isOrganizer}),
+  });
+  if (!response.ok) {
+    const data: unknown = await response.json();
+    const message =
+      typeof data === 'object' && data !== null && 'error' in data && typeof data.error === 'string'
+        ? data.error
+        : 'Failed to update organizer role';
+    throw new Error(message);
+  }
+}
+
+export function OrganizerManagement() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>('all');
+  const membersQuery = useQuery({
+    queryKey: ['admin', 'organizer-members', search],
+    queryFn: () =>
+      Effect.runPromise(
+        getMembers({
+          page: 1,
+          pageSize: 100,
+          query: search || undefined,
+        }),
+      ),
+    staleTime: 60_000,
+  });
+  const roleMutation = useMutation({
+    mutationFn: updateOrganizerRole,
+    onSuccess: async (_, update) => {
+      queryClient.setQueriesData<GetMembersResponse>(
+        {queryKey: ['admin', 'organizer-members']},
+        (current) =>
+          current
+            ? {
+                ...current,
+                members: current.members.map((member) =>
+                  member.user?.id === update.userId
+                    ? {
+                        ...member,
+                        user: {...member.user, isOrganizer: update.isOrganizer},
+                      }
+                    : member,
+                ),
+              }
+            : current,
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({queryKey: ['admin', 'organizer-members']}),
+        queryClient.invalidateQueries({queryKey: ['admin', 'members']}),
+      ]);
+    },
+  });
+
+  const members: MemberWithMembership[] = membersQuery.data?.members ?? [];
+  const filteredMembers = members.filter((member) => {
+    if (roleFilter === 'all') return true;
+    const isOrganizer = member.user?.isOrganizer === true;
+    return roleFilter === 'organizer' ? isOrganizer : !isOrganizer;
+  });
+
+  return (
+    <Box sx={{display: 'grid', gap: 3}}>
+      <Paper className="dec-card" sx={{p: 3}}>
+        <Box sx={{display: 'flex', gap: 2, alignItems: 'center', mb: 1}}>
+          <ManageAccountsIcon color="primary" />
+          <Typography variant="h4" component="h2">
+            Organizer access
+          </Typography>
+        </Box>
+        <Typography color="text.secondary">
+          Organizers can view membership reports, send password reset emails, and update trail
+          status. They cannot change members, access payments, run reconciliation, or manage roles.
+          Organizer access is available only while their membership is current.
+        </Typography>
+      </Paper>
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 2,
+          alignItems: {xs: 'stretch', sm: 'center'},
+          flexDirection: {xs: 'column', sm: 'row'},
+        }}
+      >
+        <TextField
+          label="Search members"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Name or email"
+          size="small"
+          sx={{flex: 1}}
+        />
+        <ToggleButtonGroup
+          value={roleFilter}
+          exclusive
+          size="small"
+          onChange={(_, value: RoleFilter | null) => {
+            if (value) setRoleFilter(value);
+          }}
+          aria-label="Filter by role"
+        >
+          <ToggleButton value="all">All</ToggleButton>
+          <ToggleButton value="organizer">Organizers</ToggleButton>
+          <ToggleButton value="member">Members</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
+      {roleMutation.error && <Alert severity="error">{roleMutation.error.message}</Alert>}
+
+      {membersQuery.isLoading ? (
+        <Box sx={{display: 'grid', placeItems: 'center', py: 8}}>
+          <CircularProgress />
+        </Box>
+      ) : membersQuery.error ? (
+        <Alert severity="error">{membersQuery.error.message}</Alert>
+      ) : (
+        <TableContainer component={Paper} className="dec-card">
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Email</TableCell>
+                <TableCell>Membership</TableCell>
+                <TableCell>Access</TableCell>
+                <TableCell align="right">Action</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredMembers.map((member) => {
+                const user = member.user;
+                if (!user) return null;
+                const isOrganizer = user.isOrganizer === true;
+                const hasEligibleMembership = hasCurrentMembership(member.membership);
+                const hasOrganizerAccess = isOrganizer && hasEligibleMembership;
+                const isUpdating =
+                  roleMutation.isPending && roleMutation.variables?.userId === user.id;
+                return (
+                  <TableRow key={user.id}>
+                    <TableCell>{user.name || 'Not set'}</TableCell>
+                    <TableCell>{user.email}</TableCell>
+                    <TableCell>
+                      {hasEligibleMembership
+                        ? member.card?.membershipNumber || 'Current'
+                        : 'Inactive'}
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={
+                          hasOrganizerAccess
+                            ? 'Organizer'
+                            : isOrganizer
+                              ? 'Organizer (inactive)'
+                              : 'Member'
+                        }
+                        color={hasOrganizerAccess ? 'primary' : 'default'}
+                        size="small"
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      <Button
+                        variant={isOrganizer ? 'outlined' : 'contained'}
+                        color={isOrganizer ? 'error' : 'primary'}
+                        disabled={isUpdating || (!isOrganizer && !hasEligibleMembership)}
+                        onClick={() =>
+                          roleMutation.mutate({userId: user.id, isOrganizer: !isOrganizer})
+                        }
+                      >
+                        {isUpdating ? '…' : isOrganizer ? 'Revoke' : 'Grant'}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+}

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -3,10 +3,12 @@
 import {onAuthStateChanged, User} from 'firebase/auth';
 import {createContext, useContext, useEffect, useState, ReactNode} from 'react';
 
+import type {AccessRole} from '@/src/lib/access-control';
 import {auth} from '@/src/utils/firebase';
 
 interface AuthContextType {
   user: User | null;
+  role: AccessRole | null;
   loading: boolean;
   signOut: () => Promise<void>;
 }
@@ -15,6 +17,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({children}: {children: ReactNode}) {
   const [user, setUser] = useState<User | null>(null);
+  const [role, setRole] = useState<AccessRole | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -27,11 +30,24 @@ export function AuthProvider({children}: {children: ReactNode}) {
           headers: {'Content-Type': 'application/json'},
           body: JSON.stringify({idToken}),
         });
+        const accessResponse = await fetch('/api/admin/check');
+        const accessData: unknown = accessResponse.ok ? await accessResponse.json() : null;
+        const accessRole =
+          typeof accessData === 'object' &&
+          accessData !== null &&
+          'role' in accessData &&
+          (accessData.role === 'admin' ||
+            accessData.role === 'organizer' ||
+            accessData.role === 'member')
+            ? accessData.role
+            : 'member';
         setUser(firebaseUser);
+        setRole(accessRole);
       } else {
         // Clear session
         await fetch('/api/auth/session', {method: 'DELETE'});
         setUser(null);
+        setRole(null);
       }
       setLoading(false);
     });
@@ -43,10 +59,11 @@ export function AuthProvider({children}: {children: ReactNode}) {
     await auth.signOut();
     await fetch('/api/auth/session', {method: 'DELETE'});
     setUser(null);
+    setRole(null);
   };
 
   return (
-    <AuthContext.Provider value={{user, loading, signOut: handleSignOut}}>
+    <AuthContext.Provider value={{user, role, loading, signOut: handleSignOut}}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import {useRouter} from 'next/navigation';
 import {useState, useEffect} from 'react';
 
-import {loginWithPassword, sendMagicLink} from '@/src/lib/effect/client-auth';
+import {getCurrentAccessRole, loginWithPassword, sendMagicLink} from '@/src/lib/effect/client-auth';
 import type {AuthError} from '@/src/lib/effect/errors';
 import {auth} from '@/src/utils/firebase';
 
@@ -56,15 +56,8 @@ export function LoginForm() {
           if (response.ok) {
             const data = await response.json();
             if (data.authenticated) {
-              const adminEmail = (
-                process.env.NEXT_PUBLIC_ALLOWED_EMAIL || 'info@downeastcyclists.com'
-              )
-                .toLowerCase()
-                .trim();
-              const userEmail = (data.email || '').toLowerCase().trim();
-              const isAdmin = userEmail === adminEmail;
-
-              window.location.href = isAdmin ? '/dashboard' : '/member';
+              const role = await Effect.runPromise(getCurrentAccessRole());
+              window.location.href = role === 'member' ? '/member' : '/dashboard';
             }
           }
         } catch {
@@ -79,17 +72,9 @@ export function LoginForm() {
   // Email/Password Login Mutation - using Effect
   const loginMutation = useMutation<unknown, AuthError, LoginCredentials>({
     mutationFn: (credentials) => Effect.runPromise(loginWithPassword(credentials)),
-    onSuccess: (_, variables) => {
-      // Check if user is admin - normalize email comparison
-      const adminEmail = (process.env.NEXT_PUBLIC_ALLOWED_EMAIL || 'info@downeastcyclists.com')
-        .toLowerCase()
-        .trim();
-      const userEmail = variables.email.toLowerCase().trim();
-      const isAdmin = userEmail === adminEmail;
-
-      // Use window.location for a hard redirect to ensure it works
-      const redirectUrl = isAdmin ? '/dashboard' : '/member';
-      window.location.href = redirectUrl;
+    onSuccess: async () => {
+      const role = await Effect.runPromise(getCurrentAccessRole());
+      window.location.href = role === 'member' ? '/member' : '/dashboard';
     },
   });
 

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -77,7 +77,7 @@ export default function Navbar() {
   const currentPath = pathname || '/';
   const router = useRouter();
   const {mode, toggleMode} = useThemeMode();
-  const {user, loading, signOut} = useAuth();
+  const {user, role, loading, signOut} = useAuth();
 
   const isActive = (href: string) => {
     if (href === '/trails/b3') return currentPath.startsWith('/trails');
@@ -139,7 +139,16 @@ export default function Navbar() {
                   {item.label}
                 </Box>
               ) : item.children ? (
-                <Box key={item.href} className="group" sx={{position: 'relative', minHeight: 44, display: 'inline-flex', alignItems: 'center'}}>
+                <Box
+                  key={item.href}
+                  className="group"
+                  sx={{
+                    position: 'relative',
+                    minHeight: 44,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                  }}
+                >
                   <Box
                     component={Link}
                     href={item.href}
@@ -150,7 +159,9 @@ export default function Navbar() {
                       minHeight: 44,
                       display: 'inline-flex',
                       alignItems: 'center',
-                      borderBottom: isActive(item.href) ? '2px solid #F20E02' : '2px solid transparent',
+                      borderBottom: isActive(item.href)
+                        ? '2px solid #F20E02'
+                        : '2px solid transparent',
                     }}
                   >
                     {item.label}
@@ -164,7 +175,7 @@ export default function Navbar() {
                       zIndex: 20,
                       minWidth: 210,
                       flexDirection: 'column',
-                      gap: .5,
+                      gap: 0.5,
                       p: 1,
                       bgcolor: 'var(--dec-surface)',
                       border: '1px solid var(--dec-border)',
@@ -184,7 +195,9 @@ export default function Navbar() {
                           color: currentPath === child.href ? '#F20E02' : 'var(--dec-muted)',
                           fontSize: 14,
                           fontWeight: 700,
-                          '&:hover': {bgcolor: 'color-mix(in srgb, var(--dec-border) 40%, transparent)'},
+                          '&:hover': {
+                            bgcolor: 'color-mix(in srgb, var(--dec-border) 40%, transparent)',
+                          },
                         }}
                       >
                         {child.label}
@@ -204,7 +217,9 @@ export default function Navbar() {
                     minHeight: 44,
                     display: 'inline-flex',
                     alignItems: 'center',
-                    borderBottom: isActive(item.href) ? '2px solid #F20E02' : '2px solid transparent',
+                    borderBottom: isActive(item.href)
+                      ? '2px solid #F20E02'
+                      : '2px solid transparent',
                   }}
                 >
                   {item.label}
@@ -222,7 +237,7 @@ export default function Navbar() {
               {mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
             </IconButton>
 
-            {!loading && user && (
+            {!loading && user && role !== 'admin' && (
               <Button
                 component={Link}
                 href="/member"
@@ -236,7 +251,7 @@ export default function Navbar() {
                   whiteSpace: 'nowrap',
                 }}
               >
-                {user.displayName || user.email?.split('@')[0] || 'My Account'}
+                My Account
               </Button>
             )}
 
@@ -267,25 +282,52 @@ export default function Navbar() {
               </Button>
             )}
 
-            <Button
-              component={Link}
-              href={user ? '/member' : '/join'}
-              variant="contained"
-              sx={{
-                bgcolor: '#F20E02',
-                borderRadius: 999,
-                px: {xs: 2, md: 2.75},
-                '&:hover': {bgcolor: '#b30a01'},
-              }}
-            >
-              {user ? 'My Account' : <Box component="span" sx={{display: {xs: 'none', sm: 'inline'}}}>Join the club</Box>}
-              {!user && <Box component="span" sx={{display: {xs: 'inline', sm: 'none'}}}>Join</Box>}
-            </Button>
+            {!loading && user && (role === 'admin' || role === 'organizer') && (
+              <Button
+                component={Link}
+                href="/dashboard"
+                variant="contained"
+                sx={{
+                  bgcolor: '#F20E02',
+                  borderRadius: 999,
+                  px: {xs: 2, md: 2.75},
+                  '&:hover': {bgcolor: '#b30a01'},
+                }}
+              >
+                Admin Dashboard
+              </Button>
+            )}
+
+            {!loading && !user && (
+              <Button
+                component={Link}
+                href="/join"
+                variant="contained"
+                sx={{
+                  bgcolor: '#F20E02',
+                  borderRadius: 999,
+                  px: {xs: 2, md: 2.75},
+                  '&:hover': {bgcolor: '#b30a01'},
+                }}
+              >
+                <Box component="span" sx={{display: {xs: 'none', sm: 'inline'}}}>
+                  Join the club
+                </Box>
+                <Box component="span" sx={{display: {xs: 'inline', sm: 'none'}}}>
+                  Join
+                </Box>
+              </Button>
+            )}
 
             <IconButton
               aria-label="Open navigation menu"
               onClick={(event) => setAnchorElNav(event.currentTarget)}
-              sx={{display: {xs: 'inline-flex', md: 'none'}, color: 'var(--dec-ink)', width: 44, height: 44}}
+              sx={{
+                display: {xs: 'inline-flex', md: 'none'},
+                color: 'var(--dec-ink)',
+                width: 44,
+                height: 44,
+              }}
             >
               {anchorElNav ? <CloseIcon /> : <MenuIcon />}
             </IconButton>
@@ -310,22 +352,32 @@ export default function Navbar() {
           >
             {navItems.map((item) => (
               <Box key={item.href}>
-              <MenuItem onClick={closeMenu} sx={{minHeight: 48}}>
-                {item.external ? (
-                  <a href={item.href} target="_blank" rel="noopener noreferrer">
-                    {item.label}
-                  </a>
-                ) : (
-                  <Link href={item.href}>{item.label}</Link>
-                )}
-              </MenuItem>
-              {item.children?.map((child) => (
-                <MenuItem key={child.href} onClick={closeMenu} sx={{minHeight: 44, pl: 4}}>
-                  <Link href={child.href}>{child.label}</Link>
+                <MenuItem onClick={closeMenu} sx={{minHeight: 48}}>
+                  {item.external ? (
+                    <a href={item.href} target="_blank" rel="noopener noreferrer">
+                      {item.label}
+                    </a>
+                  ) : (
+                    <Link href={item.href}>{item.label}</Link>
+                  )}
                 </MenuItem>
-              ))}
+                {item.children?.map((child) => (
+                  <MenuItem key={child.href} onClick={closeMenu} sx={{minHeight: 44, pl: 4}}>
+                    <Link href={child.href}>{child.label}</Link>
+                  </MenuItem>
+                ))}
               </Box>
             ))}
+            {user && role !== 'admin' && (
+              <MenuItem onClick={closeMenu} sx={{minHeight: 48}}>
+                <Link href="/member">My Account</Link>
+              </MenuItem>
+            )}
+            {user && (role === 'admin' || role === 'organizer') && (
+              <MenuItem onClick={closeMenu} sx={{minHeight: 48}}>
+                <Link href="/dashboard">Admin Dashboard</Link>
+              </MenuItem>
+            )}
             <MenuItem onClick={handleAuthClick} sx={{minHeight: 48}}>
               {user ? 'Log out' : 'Log in'}
             </MenuItem>

--- a/src/db/schema/tables.ts
+++ b/src/db/schema/tables.ts
@@ -38,6 +38,7 @@ export const users = pgTable(
     addressState: varchar('address_state', {length: 50}),
     addressZip: varchar('address_zip', {length: 20}),
     stripeCustomerId: varchar('stripe_customer_id', {length: 255}),
+    isOrganizer: boolean('is_organizer').notNull().default(false),
     createdAt: timestamp('created_at', {withTimezone: true}).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).defaultNow().notNull(),
   },

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -1,0 +1,76 @@
+export type AccessRole = 'member' | 'organizer' | 'admin';
+
+export type StaffRole = Exclude<AccessRole, 'member'>;
+
+interface MembershipEligibility {
+  readonly status: string;
+  readonly endDate: unknown;
+}
+
+export type DashboardCapability =
+  | 'dashboard:view'
+  | 'members:read'
+  | 'members:write'
+  | 'members:export'
+  | 'members:audit'
+  | 'members:password-reset'
+  | 'members:payments'
+  | 'members:refund'
+  | 'members:import'
+  | 'stats:read'
+  | 'stats:refresh'
+  | 'trails:update'
+  | 'reconciliation:run'
+  | 'organizers:manage';
+
+const organizerCapabilities: ReadonlySet<DashboardCapability> = new Set([
+  'dashboard:view',
+  'members:read',
+  'members:export',
+  'members:audit',
+  'members:password-reset',
+  'stats:read',
+  'stats:refresh',
+  'trails:update',
+]);
+
+const adminCapabilities: ReadonlySet<DashboardCapability> = new Set([
+  ...organizerCapabilities,
+  'members:write',
+  'members:payments',
+  'members:refund',
+  'members:import',
+  'reconciliation:run',
+  'organizers:manage',
+]);
+
+export interface AccessSession {
+  readonly uid: string;
+  readonly email?: string;
+  readonly role: AccessRole;
+}
+
+export function hasDashboardCapability(role: AccessRole, capability: DashboardCapability): boolean {
+  if (role === 'admin') return adminCapabilities.has(capability);
+  if (role === 'organizer') return organizerCapabilities.has(capability);
+  return false;
+}
+
+export function getDashboardCapabilities(role: AccessRole): DashboardCapability[] {
+  if (role === 'admin') return [...adminCapabilities];
+  if (role === 'organizer') return [...organizerCapabilities];
+  return [];
+}
+
+export function hasCurrentMembership(
+  membership: MembershipEligibility | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!membership || (membership.status !== 'active' && membership.status !== 'trialing')) {
+    return false;
+  }
+
+  const endDate =
+    membership.endDate instanceof Date ? membership.endDate : new Date(String(membership.endDate));
+  return !Number.isNaN(endDate.getTime()) && endDate >= now;
+}

--- a/src/lib/api/admin-route-handler.ts
+++ b/src/lib/api/admin-route-handler.ts
@@ -18,6 +18,7 @@ type AdminErrorTag =
   | 'QRError'
   | 'AdminError'
   | 'MemberNotFoundError'
+  | 'NotFoundError'
   | 'EmailConflictError'
   | 'EmailError'
   | 'StripeSubscriptionActiveError'
@@ -55,6 +56,8 @@ const errorHandlers = {
     Effect.succeed({error: error.message, _tag: 'error' as const, status: 500}),
   MemberNotFoundError: (error: {message: string}) =>
     Effect.succeed({error: error.message, _tag: 'error' as const, status: 404}),
+  NotFoundError: (error: {resource: string}) =>
+    Effect.succeed({error: `${error.resource} not found`, _tag: 'error' as const, status: 404}),
   EmailConflictError: (error: {message: string}) =>
     Effect.succeed({error: error.message, _tag: 'error' as const, status: 409}),
   StripeSubscriptionActiveError: (error: {message: string}) =>

--- a/src/lib/effect/admin.service.ts
+++ b/src/lib/effect/admin.service.ts
@@ -1,6 +1,13 @@
 import {Context, Effect, Layer, pipe} from 'effect';
 import type Stripe from 'stripe';
 
+import {
+  type AccessSession,
+  type DashboardCapability,
+  hasCurrentMembership,
+  hasDashboardCapability,
+} from '@/src/lib/access-control';
+import {isPrimaryAdminEmail} from '@/src/lib/primary-admin';
 import type {
   AuditEntry,
   BulkImportResult,
@@ -49,17 +56,29 @@ import {StripeService} from './stripe.service';
 
 // Service interface
 export interface AdminService {
+  readonly getAccess: (
+    sessionCookie: string,
+  ) => Effect.Effect<AccessSession, SessionError | AuthError | DatabaseError>;
+
+  readonly authorize: (
+    sessionCookie: string,
+    capability: DashboardCapability,
+  ) => Effect.Effect<AccessSession, UnauthorizedError | SessionError | AuthError | DatabaseError>;
+
   readonly verifyAdmin: (
     sessionCookie: string,
-  ) => Effect.Effect<{uid: string; email?: string}, UnauthorizedError | SessionError | AuthError>;
+  ) => Effect.Effect<
+    {uid: string; email?: string},
+    UnauthorizedError | SessionError | AuthError | DatabaseError
+  >;
 
-  readonly setAdminRole: (
+  readonly setOrganizerRole: (
     adminSessionCookie: string,
     targetUid: string,
-    isAdmin: boolean,
+    isOrganizer: boolean,
   ) => Effect.Effect<
     void,
-    UnauthorizedError | AdminError | SessionError | AuthError | DatabaseError
+    UnauthorizedError | AdminError | SessionError | AuthError | DatabaseError | NotFoundError
   >;
 
   readonly searchMembers: (
@@ -159,24 +178,6 @@ export interface AdminService {
 
 // Service tag
 export const AdminService = Context.GenericTag<AdminService>('AdminService');
-
-// Admin email whitelist for defense in depth
-// Loaded from ADMIN_EMAIL_WHITELIST env var (comma-separated list)
-const getAdminWhitelist = (): string[] => {
-  const whitelist = process.env.ADMIN_EMAIL_WHITELIST;
-  if (!whitelist) {
-    return [];
-  }
-  return whitelist.split(',').map((email) => email.trim().toLowerCase());
-};
-
-const isEmailInAdminWhitelist = (email: string | undefined): boolean => {
-  if (!email) return false;
-  const whitelist = getAdminWhitelist();
-  // If no whitelist is configured, fall back to claim-only verification
-  if (whitelist.length === 0) return true;
-  return whitelist.includes(email.toLowerCase());
-};
 
 // Helper functions for reconciliation
 
@@ -390,6 +391,44 @@ const make = Effect.gen(function* () {
   const cardService = yield* MembershipCardService;
   const emailService = yield* EmailService;
 
+  const getAccess = Effect.fn('AdminService.getAccess')(function* (sessionCookie: string) {
+    const session = yield* auth.verifyAdminClaim(sessionCookie);
+    const sessionEmail = session.email?.trim().toLowerCase();
+
+    if (session.isAdmin && isPrimaryAdminEmail(sessionEmail)) {
+      return {
+        uid: session.uid,
+        email: session.email,
+        role: 'admin' as const,
+      };
+    }
+
+    const user = yield* db.getUser(session.uid);
+    const membership =
+      user?.isOrganizer === true ? yield* db.getActiveMembership(session.uid) : null;
+    return {
+      uid: session.uid,
+      email: session.email,
+      role:
+        user?.isOrganizer === true && hasCurrentMembership(membership)
+          ? ('organizer' as const)
+          : ('member' as const),
+    };
+  });
+
+  const authorize = Effect.fn('AdminService.authorize')(function* (
+    sessionCookie: string,
+    capability: DashboardCapability,
+  ) {
+    const access = yield* getAccess(sessionCookie);
+    if (!hasDashboardCapability(access.role, capability)) {
+      return yield* new UnauthorizedError({
+        message: 'You do not have permission to perform this action',
+      });
+    }
+    return access;
+  });
+
   // Shared helper function to build reconciliation report
   // This avoids code duplication between validateStripeVsDatabase and reconcileMembership
   const buildReconciliationReport = (
@@ -475,9 +514,9 @@ const make = Effect.gen(function* () {
         lookupDiagnostics.subscriptionLookupCount += subscriptions.length;
         const activeSubscription =
           subscriptions.find(
-            (sub) => sub.status === 'active' || sub.status === 'trialing' || sub.status === 'past_due',
-          ) ||
-          subscriptions[0];
+            (sub) =>
+              sub.status === 'active' || sub.status === 'trialing' || sub.status === 'past_due',
+          ) || subscriptions[0];
 
         if (activeSubscription) {
           stripeCustomer = candidateCustomer;
@@ -529,7 +568,11 @@ const make = Effect.gen(function* () {
       }
 
       // Detect discrepancies
-      const discrepancies = detectDiscrepancies(stripeData, databaseData, stripeCustomers.length > 0);
+      const discrepancies = detectDiscrepancies(
+        stripeData,
+        databaseData,
+        stripeCustomers.length > 0,
+      );
       const reconcileActions = generateReconcileActions(discrepancies, stripeData, databaseData);
 
       return {
@@ -547,58 +590,48 @@ const make = Effect.gen(function* () {
     });
 
   return AdminService.of({
-    // Verify admin access with defense in depth (claim + whitelist)
+    getAccess,
+    authorize,
+
     verifyAdmin: (sessionCookie) =>
-      pipe(
-        auth.verifyAdminClaim(sessionCookie),
-        Effect.flatMap((session) => {
-          // First check: admin claim must be true
-          if (!session.isAdmin) {
-            return Effect.fail(
-              new UnauthorizedError({
-                message: 'Admin access required',
-              }),
-            );
-          }
-
-          // Second check: email must be in whitelist (if whitelist is configured)
-          if (!isEmailInAdminWhitelist(session.email)) {
-            return Effect.fail(
-              new UnauthorizedError({
-                message: 'Admin email not in authorized whitelist',
-              }),
-            );
-          }
-
-          return Effect.succeed({uid: session.uid, email: session.email});
-        }),
+      authorize(sessionCookie, 'organizers:manage').pipe(
+        Effect.map(({uid, email}) => ({uid, email})),
       ),
 
-    // Set admin role for a user
-    setAdminRole: (adminSessionCookie, targetUid, isAdmin) =>
+    setOrganizerRole: (adminSessionCookie, targetUid, isOrganizer) =>
       Effect.gen(function* () {
-        // Verify caller is admin
-        const admin = yield* pipe(
-          auth.verifyAdminClaim(adminSessionCookie),
-          Effect.flatMap((session) =>
-            session.isAdmin
-              ? Effect.succeed(session)
-              : Effect.fail(new UnauthorizedError({message: 'Admin access required'})),
-          ),
-        );
+        const admin = yield* authorize(adminSessionCookie, 'organizers:manage');
+        const member = yield* db.getUser(targetUid);
+        if (!member) {
+          return yield* new NotFoundError({resource: 'member', id: targetUid});
+        }
+        if (isPrimaryAdminEmail(member.email)) {
+          return yield* new AdminError({
+            code: 'ADMIN_ROLE_IMMUTABLE',
+            message: 'The administrator account cannot be assigned an organizer role',
+          });
+        }
+        if (isOrganizer) {
+          const membership = yield* db.getActiveMembership(targetUid);
+          if (!hasCurrentMembership(membership)) {
+            return yield* new AdminError({
+              code: 'ORGANIZER_MEMBERSHIP_REQUIRED',
+              message: 'Organizer access requires a current active membership',
+            });
+          }
+        }
 
-        // Set custom claim
-        yield* auth.setCustomClaims(targetUid, {admin: isAdmin});
-
-        // Log the action
+        yield* db.updateUser(targetUid, {isOrganizer});
         yield* db.logAuditEntry(targetUid, 'ADMIN_ROLE_CHANGE', {
-          changedBy: admin.uid,
-          newValue: isAdmin,
+          performedBy: admin.uid,
+          performedByEmail: admin.email,
+          role: 'organizer',
+          newValue: isOrganizer,
           timestamp: new Date().toISOString(),
         });
 
         yield* Effect.log(
-          `Admin role ${isAdmin ? 'granted to' : 'revoked from'} ${targetUid} by ${admin.uid}`,
+          `Organizer role ${isOrganizer ? 'granted to' : 'revoked from'} ${targetUid} by ${admin.uid}`,
         );
       }),
 

--- a/src/lib/effect/client-auth.ts
+++ b/src/lib/effect/client-auth.ts
@@ -5,6 +5,7 @@ import {
   type UserCredential,
 } from 'firebase/auth';
 
+import type {AccessRole} from '@/src/lib/access-control';
 import {auth} from '@/src/utils/firebase';
 
 import {AuthError} from './errors';
@@ -22,6 +23,30 @@ interface LoginCredentials {
   email: string;
   password: string;
 }
+
+export const getCurrentAccessRole = (): Effect.Effect<AccessRole, AuthError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch('/api/admin/check');
+      if (!response.ok) return 'member';
+      const data: unknown = await response.json();
+      if (
+        typeof data === 'object' &&
+        data !== null &&
+        'role' in data &&
+        (data.role === 'admin' || data.role === 'organizer' || data.role === 'member')
+      ) {
+        return data.role;
+      }
+      return 'member';
+    },
+    catch: (error) =>
+      new AuthError({
+        code: 'ACCESS_CHECK_FAILED',
+        message: 'Failed to determine account access',
+        cause: error,
+      }),
+  });
 
 // Sign in with email/password
 export const signInWithPassword = (

--- a/src/lib/effect/database-membership.methods.ts
+++ b/src/lib/effect/database-membership.methods.ts
@@ -51,6 +51,7 @@ function rowToUserDocument(row: typeof users.$inferSelect): UserDocument {
       zip: row.addressZip ?? undefined,
     },
     stripeCustomerId: row.stripeCustomerId ?? undefined,
+    isOrganizer: row.isOrganizer,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };

--- a/src/lib/effect/database.service.ts
+++ b/src/lib/effect/database.service.ts
@@ -45,6 +45,7 @@ function rowToUserDocument(row: typeof users.$inferSelect): UserDocument {
       zip: row.addressZip ?? undefined,
     },
     stripeCustomerId: row.stripeCustomerId ?? undefined,
+    isOrganizer: row.isOrganizer,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   };
@@ -291,6 +292,7 @@ const make = Effect.sync(() => {
               addressState: data.address?.state ?? null,
               addressZip: data.address?.zip ?? null,
               stripeCustomerId: data.stripeCustomerId ?? null,
+              isOrganizer: data.isOrganizer ?? false,
               createdAt: now,
               updatedAt: now,
             })
@@ -318,6 +320,7 @@ const make = Effect.sync(() => {
           if (data.phone !== undefined) updates.phone = data.phone ?? null;
           if (data.stripeCustomerId !== undefined)
             updates.stripeCustomerId = data.stripeCustomerId ?? null;
+          if (data.isOrganizer !== undefined) updates.isOrganizer = data.isOrganizer;
 
           if (data.address) {
             if (data.address.street !== undefined)
@@ -352,6 +355,7 @@ const make = Effect.sync(() => {
             if (data.phone !== undefined) values.phone = data.phone ?? null;
             if (data.stripeCustomerId !== undefined)
               values.stripeCustomerId = data.stripeCustomerId ?? null;
+            if (data.isOrganizer !== undefined) values.isOrganizer = data.isOrganizer;
 
             if (data.address) {
               if (data.address.street !== undefined)
@@ -393,6 +397,7 @@ const make = Effect.sync(() => {
               addressState: data.address?.state ?? null,
               addressZip: data.address?.zip ?? null,
               stripeCustomerId: data.stripeCustomerId ?? null,
+              isOrganizer: data.isOrganizer ?? false,
               createdAt: now,
               updatedAt: now,
             });
@@ -462,6 +467,7 @@ const make = Effect.sync(() => {
               addressState: defaultData.address?.state ?? null,
               addressZip: defaultData.address?.zip ?? null,
               stripeCustomerId,
+              isOrganizer: defaultData.isOrganizer ?? false,
               createdAt: now,
               updatedAt: now,
             })

--- a/src/lib/effect/schemas.ts
+++ b/src/lib/effect/schemas.ts
@@ -33,6 +33,7 @@ export const UserDocument = S.Struct({
   phone: S.optional(S.String),
   address: S.optional(Address),
   stripeCustomerId: S.optional(S.String),
+  isOrganizer: S.optional(S.Boolean),
   createdAt: S.Any,
   updatedAt: S.Any,
 });
@@ -352,9 +353,7 @@ export const ReconciliationLookupDiagnostics = S.Struct({
   emailCustomerCount: S.Number,
   subscriptionLookupCount: S.Number,
 });
-export type ReconciliationLookupDiagnostics = S.Schema.Type<
-  typeof ReconciliationLookupDiagnostics
->;
+export type ReconciliationLookupDiagnostics = S.Schema.Type<typeof ReconciliationLookupDiagnostics>;
 
 // Database data snapshot for comparison
 export const DatabaseDataSnapshot = S.Struct({

--- a/src/lib/meetup/events.ts
+++ b/src/lib/meetup/events.ts
@@ -1,4 +1,5 @@
 import {asc, gt} from 'drizzle-orm';
+import {unstable_cache} from 'next/cache';
 
 import {meetupEvents} from '@/src/db/schema/tables';
 
@@ -26,30 +27,42 @@ const formatRideMeta = (date: Date, location: string | null) => {
   return location ? `${formattedDate} · ${location}` : formattedDate;
 };
 
-export async function getUpcomingMeetupRides(limit = 5): Promise<UpcomingMeetupRide[]> {
-  try {
-    const db = getDb();
-    const rows = await db
-      .select({
-        title: meetupEvents.title,
-        link: meetupEvents.url,
-        startDate: meetupEvents.startDate,
-        location: meetupEvents.location,
-      })
-      .from(meetupEvents)
-      .where(gt(meetupEvents.startDate, new Date()))
-      .orderBy(asc(meetupEvents.startDate))
-      .limit(limit);
+const FOUR_HOURS_IN_SECONDS = 60 * 60 * 4;
 
-    return rows.map((row) => ({
-      title: row.title,
-      link: row.link,
-      date: row.startDate.toISOString(),
-      meta: formatRideMeta(row.startDate, row.location),
-      location: row.location,
-    }));
-  } catch (error) {
-    console.error('Failed to load upcoming Meetup rides from Neon:', error);
-    return [];
-  }
+const getUpcomingMeetupRidesCached = unstable_cache(
+  async (limit: number): Promise<UpcomingMeetupRide[]> => {
+    try {
+      const db = getDb();
+      const rows = await db
+        .select({
+          title: meetupEvents.title,
+          link: meetupEvents.url,
+          startDate: meetupEvents.startDate,
+          location: meetupEvents.location,
+        })
+        .from(meetupEvents)
+        .where(gt(meetupEvents.startDate, new Date()))
+        .orderBy(asc(meetupEvents.startDate))
+        .limit(limit);
+
+      return rows.map((row) => ({
+        title: row.title,
+        link: row.link,
+        date: row.startDate.toISOString(),
+        meta: formatRideMeta(row.startDate, row.location),
+        location: row.location,
+      }));
+    } catch (error) {
+      console.error('Failed to load upcoming Meetup rides from Neon:', error);
+      return [];
+    }
+  },
+  ['upcoming-meetup-rides'],
+  {
+    revalidate: FOUR_HOURS_IN_SECONDS,
+  },
+);
+
+export async function getUpcomingMeetupRides(limit = 5): Promise<UpcomingMeetupRide[]> {
+  return getUpcomingMeetupRidesCached(limit);
 }

--- a/src/lib/primary-admin.ts
+++ b/src/lib/primary-admin.ts
@@ -1,0 +1,14 @@
+export function getPrimaryAdminEmail(): string {
+  return (
+    process.env.ADMIN_EMAIL ||
+    process.env.ADMIN_EMAIL_WHITELIST?.split(',')[0] ||
+    process.env.NEXT_PUBLIC_ALLOWED_EMAIL ||
+    'info@downeastcyclists.com'
+  )
+    .trim()
+    .toLowerCase();
+}
+
+export function isPrimaryAdminEmail(email: string | undefined): boolean {
+  return email?.trim().toLowerCase() === getPrimaryAdminEmail();
+}


### PR DESCRIPTION
## Summary
- add a single-admin access model with member-based organizer role management
- add an admin-only organizer screen with search, role filters, grant/revoke actions, and audit logging
- give organizers limited dashboard, member reporting, password reset, export, stats, and trail-status capabilities
- hide and deny reconciliation, payment, member mutation, import, refund, and role-management capabilities for organizers
- require organizers to have a current active or trialing membership, automatically removing effective access when dues lapse
- add My Account and Admin Dashboard navigation based on the authenticated role

## Data changes
- add the `users.is_organizer` column through Drizzle migration `0002_graceful_timeslip.sql`

## Security
- centralize capability-based authorization for admin routes
- require authenticated ownership for member membership data
- validate trail-status updates through staff authorization rather than cookie presence

## Validation
- `pnpm test:run` — 258 tests passed
- `pnpm tsc --noEmit` — passed
- `pnpm build` — passed
- `git diff --check` — passed
