### PR TITLE
Fix post-login browser history

### DIFF
--- a/app/auth-handler/page.tsx
+++ b/app/auth-handler/page.tsx
@@ -21,18 +21,19 @@ function AuthHandlerContent() {
     // Check if this is a sign-in action
     if (mode === 'signIn' && oobCode) {
       // Forward to the verify page with all parameters
-      router.push(`/verify${window.location.search}`);
+      router.replace(`/verify${window.location.search}`);
     } else if (mode === 'resetPassword' && oobCode) {
-      router.push(`/reset-password${window.location.search}`);
+      router.replace(`/reset-password${window.location.search}`);
     } else {
       // Unknown mode or missing parameters
-      router.push('/login');
+      router.replace('/login');
     }
   }, [searchParams, router]);
 
   return (
     <Container maxWidth="xs" className="dec-page">
-      <Box className="dec-card"
+      <Box
+        className="dec-card"
         sx={{
           marginTop: 8,
           p: 4,

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -32,7 +32,7 @@ export default function VerifyPage() {
     mutationFn: (email) => Effect.runPromise(completeMagicLinkSignIn(email, window.location.href)),
     onSuccess: async () => {
       const role = await Effect.runPromise(getCurrentAccessRole());
-      window.location.href = role === 'member' ? '/member' : '/dashboard';
+      router.replace(role === 'member' ? '/member' : '/dashboard');
     },
     onError: () => {
       // Clear the invalid link state and show error

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -34,7 +34,7 @@ export function LoginForm() {
       if (hasFirebaseActionParams) {
         // Firebase redirected us here with auth parameters
         // Forward to the verify page to handle the magic link
-        router.push(`/verify${window.location.search}`);
+        router.replace(`/verify${window.location.search}`);
         return;
       }
 
@@ -44,7 +44,7 @@ export function LoginForm() {
 
       if (isMagicLink) {
         // Redirect to verify page to handle the magic link
-        router.push(`/verify${window.location.search}`);
+        router.replace(`/verify${window.location.search}`);
         return;
       }
 
@@ -57,7 +57,7 @@ export function LoginForm() {
             const data = await response.json();
             if (data.authenticated) {
               const role = await Effect.runPromise(getCurrentAccessRole());
-              window.location.href = role === 'member' ? '/member' : '/dashboard';
+              router.replace(role === 'member' ? '/member' : '/dashboard');
             }
           }
         } catch {
@@ -74,7 +74,7 @@ export function LoginForm() {
     mutationFn: (credentials) => Effect.runPromise(loginWithPassword(credentials)),
     onSuccess: async () => {
       const role = await Effect.runPromise(getCurrentAccessRole());
-      window.location.href = role === 'member' ? '/member' : '/dashboard';
+      router.replace(role === 'member' ? '/member' : '/dashboard');
     },
   });
 


### PR DESCRIPTION
## Summary
- Replace post-login redirects with history-replacing navigation so `/login` is not left behind in the browser stack.
- Apply the same replacement behavior to magic-link forwarding and completion.

## Root Cause
Successful login flows were using full page navigation or push navigation, which left `/login` or `/auth-handler` in browser history. Pressing Back after reaching `/member` or `/dashboard` could return users to the login flow.

## Validation
- `pnpm lint`
- `pnpm tsc`
- `pnpm exec oxfmt --check app/auth-handler/page.tsx app/verify/page.tsx src/components/auth/LoginForm.tsx`

Note: full-repo `pnpm fmt:check` still reports pre-existing formatting issues in unrelated files, so this PR formats only the touched files.
