### PR TITLE
Add membership renewal flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,77 @@
+# Down East Cyclists environment variables
+# Copy this file to .env.local and replace placeholder values.
+# Do not commit real secrets.
+
+# ---------------------------------------------------------------------------
+# Site URLs
+# ---------------------------------------------------------------------------
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+SITE_URL=http://localhost:3000
+
+# Netlify sets URL automatically in deployed environments.
+URL=
+
+# ---------------------------------------------------------------------------
+# Admin access
+# ---------------------------------------------------------------------------
+ADMIN_EMAIL=admin@example.com
+ADMIN_EMAIL_WHITELIST=admin@example.com
+NEXT_PUBLIC_ALLOWED_EMAIL=info@downeastcyclists.com
+
+# ---------------------------------------------------------------------------
+# Firebase client and admin
+# ---------------------------------------------------------------------------
+NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-web-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=000000000000
+NEXT_PUBLIC_FIREBASE_APP_ID=1:000000000000:web:0000000000000000000000
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
+
+GOOGLE_PROJECT_ID=your-project-id
+GOOGLE_CLIENT_EMAIL=firebase-adminsdk-xxxxx@your-project.iam.gserviceaccount.com
+GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_WITH_PRIVATE_KEY\n-----END PRIVATE KEY-----\n"
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+NETLIFY_DATABASE_URL=postgresql://user:password@host/database?sslmode=require
+NETLIFY_DATABASE_URL_UNPOOLED=postgresql://user:password@host/database?sslmode=require
+
+# ---------------------------------------------------------------------------
+# Stripe
+# ---------------------------------------------------------------------------
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxxxx
+STRIPE_SECRET_KEY=sk_test_xxxxx
+STRIPE_WEBHOOK_SECRET=whsec_xxxxx
+STRIPE_PRICE_INDIVIDUAL=price_xxxxx
+STRIPE_PRICE_FAMILY=price_xxxxx
+
+# ---------------------------------------------------------------------------
+# Resend email
+# ---------------------------------------------------------------------------
+RESEND_API_KEY=re_xxxxx
+EMAIL_FROM="Down East Cyclists <membership@example.com>"
+RESEND_RENEWAL_TEMPLATE_ID=membership-renewal
+
+# ---------------------------------------------------------------------------
+# Contentful
+# ---------------------------------------------------------------------------
+CONTENTFUL_SPACE_ID=your-contentful-space-id
+CONTENTFUL_ACCESS_TOKEN=your-contentful-delivery-token
+CONTENTFUL_MANAGEMENT_TOKEN=your-contentful-management-token
+
+# ---------------------------------------------------------------------------
+# Membership and scheduled jobs
+# ---------------------------------------------------------------------------
+QR_SIGNING_SECRET=replace-with-a-long-random-secret
+MEETUP_INGEST_SECRET=replace-with-a-long-random-secret
+
+# ---------------------------------------------------------------------------
+# Netlify CLI and local tooling
+# ---------------------------------------------------------------------------
+NODE_ENV=development
+NETLIFY_AUTH_TOKEN=nfp_xxxxx
+CI=false

--- a/app/api/admin/members/[userId]/renewal-email/route.ts
+++ b/app/api/admin/members/[userId]/renewal-email/route.ts
@@ -1,0 +1,25 @@
+import {Effect} from 'effect';
+import {NextRequest} from 'next/server';
+
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+
+export async function POST(request: NextRequest, {params}: {params: Promise<{userId: string}>}) {
+  const {userId} = await params;
+
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        const adminUser = yield* admin.verifyAdmin(sessionCookie);
+        yield* admin.sendRenewalEmail(userId, adminUser.uid, adminUser.email);
+        return {sent: true};
+      }),
+    errorTags: [
+      'UnauthorizedError',
+      'SessionError',
+      'AuthError',
+      'DatabaseError',
+      'MemberNotFoundError',
+      'EmailError',
+    ],
+  });
+}

--- a/app/auth-handler/page.tsx
+++ b/app/auth-handler/page.tsx
@@ -21,18 +21,19 @@ function AuthHandlerContent() {
     // Check if this is a sign-in action
     if (mode === 'signIn' && oobCode) {
       // Forward to the verify page with all parameters
-      router.push(`/verify${window.location.search}`);
+      router.replace(`/verify${window.location.search}`);
     } else if (mode === 'resetPassword' && oobCode) {
-      router.push(`/reset-password${window.location.search}`);
+      router.replace(`/reset-password${window.location.search}`);
     } else {
       // Unknown mode or missing parameters
-      router.push('/login');
+      router.replace('/login');
     }
   }, [searchParams, router]);
 
   return (
     <Container maxWidth="xs" className="dec-page">
-      <Box className="dec-card"
+      <Box
+        className="dec-card"
         sx={{
           marginTop: 8,
           p: 4,

--- a/app/renew/page.tsx
+++ b/app/renew/page.tsx
@@ -1,0 +1,59 @@
+import {Alert} from '@mui/material';
+import {redirect} from 'next/navigation';
+
+import {getMemberDashboard} from '@/src/actions/portal';
+import {RenewMembershipClient} from '@/src/components/membership/RenewMembershipClient';
+
+export const metadata = {
+  title: 'Renew Membership - Down East Cyclists',
+  description: 'Renew your Down East Cyclists membership',
+};
+
+interface RenewPageProps {
+  searchParams: Promise<{canceled?: string}>;
+}
+
+export default async function RenewPage({searchParams}: RenewPageProps) {
+  const params = await searchParams;
+  const dashboardData = await getMemberDashboard();
+
+  if ('error' in dashboardData) {
+    return (
+      <main className="dec-page">
+        <section className="dec-container py-16">
+          <Alert severity="error">{dashboardData.error}</Alert>
+        </section>
+      </main>
+    );
+  }
+
+  if (
+    dashboardData.membership &&
+    dashboardData.membership.status !== 'expired' &&
+    dashboardData.membership.daysRemaining > 0
+  ) {
+    redirect('/member');
+  }
+
+  return (
+    <main className="dec-page">
+      <section className="dec-container py-16 text-center md:py-20">
+        <div className="mb-4 text-sm font-bold tracking-[.1em] text-[#F20E02]">MEMBERSHIP</div>
+        <h1 className="dec-display text-6xl md:text-[92px]">Renew membership</h1>
+        <p className="mx-auto mt-5 max-w-2xl text-lg font-light leading-8 text-[var(--dec-muted)]">
+          Choose a plan and check out securely with Stripe to restore your member benefits.
+        </p>
+      </section>
+
+      <section className="dec-container pb-20">
+        <RenewMembershipClient
+          userId={dashboardData.user.id}
+          email={dashboardData.user.email}
+          name={dashboardData.user.name}
+          canceled={params.canceled === 'true'}
+          expiredOn={dashboardData.membership?.endDate}
+        />
+      </section>
+    </main>
+  );
+}

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -32,7 +32,7 @@ export default function VerifyPage() {
     mutationFn: (email) => Effect.runPromise(completeMagicLinkSignIn(email, window.location.href)),
     onSuccess: async () => {
       const role = await Effect.runPromise(getCurrentAccessRole());
-      window.location.href = role === 'member' ? '/member' : '/dashboard';
+      router.replace(role === 'member' ? '/member' : '/dashboard');
     },
     onError: () => {
       // Clear the invalid link state and show error

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -16,7 +16,7 @@ import {useEffect, useState} from 'react';
 
 import {
   completeMagicLinkSignIn,
-  getCurrentAccessRole,
+  getPostLoginRedirectPath,
   isValidSignInLink,
 } from '@/src/lib/effect/client-auth';
 import type {AuthError} from '@/src/lib/effect/errors';
@@ -31,8 +31,8 @@ export default function VerifyPage() {
   const verifyMutation = useMutation<unknown, AuthError, string>({
     mutationFn: (email) => Effect.runPromise(completeMagicLinkSignIn(email, window.location.href)),
     onSuccess: async () => {
-      const role = await Effect.runPromise(getCurrentAccessRole());
-      router.replace(role === 'member' ? '/member' : '/dashboard');
+      const redirectPath = await Effect.runPromise(getPostLoginRedirectPath());
+      router.replace(redirectPath);
     },
     onError: () => {
       // Clear the invalid link state and show error

--- a/netlify/functions/membership-renewal-reminders.ts
+++ b/netlify/functions/membership-renewal-reminders.ts
@@ -1,0 +1,33 @@
+import {Effect, Layer} from 'effect';
+
+import {DatabaseServiceLive} from '../../src/lib/effect/database.service';
+import {EmailServiceLive} from '../../src/lib/effect/email.service';
+import {sendScheduledRenewalReminders} from '../../src/lib/effect/renewal-reminders';
+
+export const config = {
+  schedule: '@daily',
+};
+
+export default async function handler() {
+  const layer = Layer.mergeAll(DatabaseServiceLive, EmailServiceLive);
+  const result = await Effect.runPromise(
+    sendScheduledRenewalReminders.pipe(
+      Effect.provide(layer),
+      Effect.catchAll((error) =>
+        Effect.succeed({
+          error: error.message,
+          _tag: 'error' as const,
+          status: 500,
+        }),
+      ),
+    ),
+  );
+
+  if ('_tag' in result && result._tag === 'error') {
+    return Response.json({error: result.error}, {status: result.status});
+  }
+
+  return Response.json(result, {
+    headers: {'Content-Type': 'application/json'},
+  });
+}

--- a/src/__tests__/integration/admin-member-management.test.ts
+++ b/src/__tests__/integration/admin-member-management.test.ts
@@ -10,8 +10,10 @@ import {
   createTestAuthService,
   createTestDatabaseService,
   createTestEmailService,
+  createTestCardService,
   createTestStripeService,
   TestAuthLayer,
+  TestCardLayer,
   TestDatabaseLayer,
   TestEmailLayer,
   TestStripeLayer,
@@ -735,6 +737,74 @@ describe('Admin Member Management Integration', () => {
       expect(result[0].daysUntilExpiration).toBe(29);
       expect(result[1].daysUntilExpiration).toBe(29);
       expect(databaseService.getExpiringMemberships).toHaveBeenCalledWith(30);
+    });
+  });
+
+  describe('Renewal Emails', () => {
+    it('should send a renewal email and audit the action', async () => {
+      const userId = 'user_renew';
+      const emailService = createTestEmailService();
+      const databaseService = createTestDatabaseService({
+        getUser: vi.fn(() =>
+          Effect.succeed({
+            id: userId,
+            email: 'expired@example.com',
+            name: 'Expired Member',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }),
+        ),
+        getActiveMembership: vi.fn(() =>
+          Effect.succeed({
+            id: 'mem_renew',
+            stripeSubscriptionId: 'sub_renew',
+            planType: 'individual' as const,
+            status: 'expired' as const,
+            startDate: '2025-01-01T00:00:00.000Z',
+            endDate: '2026-01-01T00:00:00.000Z',
+            autoRenew: false,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }),
+        ),
+        logAuditEntry: vi.fn(() => Effect.void),
+      });
+
+      const statsService = {
+        getStats: vi.fn(() => Effect.succeed({} as any)),
+        incrementStat: vi.fn(() => Effect.void),
+        decrementStat: vi.fn(() => Effect.void),
+        refreshStats: vi.fn(() => Effect.succeed({} as any)),
+      };
+
+      const testLayer = Layer.mergeAll(
+        TestDatabaseLayer(databaseService),
+        TestAuthLayer(createTestAuthService()),
+        TestStripeLayer(createTestStripeService()),
+        TestCardLayer(createTestCardService()),
+        Layer.succeed(StatsService, statsService),
+        TestEmailLayer(emailService),
+      );
+
+      const program = Effect.gen(function* () {
+        const admin = yield* AdminService;
+        yield* admin.sendRenewalEmail(userId, 'admin_123', 'admin@example.com');
+      });
+
+      await Effect.runPromise(Effect.provide(Effect.provide(program, AdminServiceLive), testLayer));
+
+      expect(emailService.sendRenewalEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'expired@example.com',
+          name: 'Expired Member',
+          renewalUrl: expect.stringContaining('/renew'),
+        }),
+      );
+      expect(databaseService.logAuditEntry).toHaveBeenCalledWith(
+        userId,
+        'MEMBERSHIP_ADJUSTMENT',
+        expect.objectContaining({action: 'RENEWAL_EMAIL_SENT'}),
+      );
     });
   });
 

--- a/src/__tests__/layers/test-layers.ts
+++ b/src/__tests__/layers/test-layers.ts
@@ -138,6 +138,7 @@ export const createTestEmailService = (
   overrides: Partial<EmailServiceType> = {},
 ): EmailServiceType => ({
   sendWelcomeEmail: vi.fn(() => Effect.void),
+  sendRenewalEmail: vi.fn(() => Effect.void),
   ...overrides,
 });
 
@@ -252,6 +253,7 @@ export const createTestAdminService = (
   getPaymentHistory: vi.fn(() => Effect.succeed([])),
   issueRefund: vi.fn(() => Effect.die('Not mocked')) as unknown as AdminServiceType['issueRefund'],
   sendPasswordReset: vi.fn(() => Effect.void),
+  sendRenewalEmail: vi.fn(() => Effect.void),
   ...overrides,
 });
 

--- a/src/__tests__/lib/membership-status.test.ts
+++ b/src/__tests__/lib/membership-status.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+
+import {
+  getEffectiveMembershipStatus,
+  getMembershipDaysUntilExpiration,
+  isCurrentMembershipStatus,
+  isRenewalReminderDay,
+} from '@/src/lib/membership-status';
+
+describe('membership status helpers', () => {
+  const now = new Date('2026-07-25T12:00:00.000Z');
+
+  it('marks date-expired active records as expired', () => {
+    expect(getEffectiveMembershipStatus('active', '2026-05-28T00:00:00.000Z', now)).toBe('expired');
+  });
+
+  it('keeps current active records active', () => {
+    expect(getEffectiveMembershipStatus('active', '2027-05-28T00:00:00.000Z', now)).toBe('active');
+  });
+
+  it('treats expired records as not current', () => {
+    expect(isCurrentMembershipStatus('active', '2026-05-28T00:00:00.000Z', now)).toBe(false);
+    expect(isCurrentMembershipStatus('active', '2027-05-28T00:00:00.000Z', now)).toBe(true);
+  });
+
+  it('recognizes only the configured reminder days', () => {
+    expect(getMembershipDaysUntilExpiration('2026-08-24T12:00:00.000Z', now)).toBe(30);
+    expect(isRenewalReminderDay(30)).toBe(true);
+    expect(isRenewalReminderDay(29)).toBe(false);
+  });
+});

--- a/src/__tests__/services/portal.service.test.ts
+++ b/src/__tests__/services/portal.service.test.ts
@@ -190,6 +190,42 @@ describe('PortalService', () => {
       expect(result.membership?.daysRemaining).toBeLessThanOrEqual(31);
     });
 
+    it('should return expired status for stale active memberships', async () => {
+      const mockUser = createMockUserDocument();
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 10);
+      const mockMembership = createMockMembershipDocument({
+        status: 'expired',
+        endDate: pastDate.toISOString(),
+      });
+
+      const authService = createTestAuthService();
+      const stripeService = createTestStripeService();
+      const databaseService = createTestDatabaseService({
+        getUser: vi.fn(() => Effect.succeed(mockUser)),
+        getActiveMembership: vi.fn(() => Effect.succeed(mockMembership)),
+      });
+
+      const testLayer = Layer.mergeAll(
+        TestAuthLayer(authService),
+        TestStripeLayer(stripeService),
+        TestDatabaseLayer(databaseService),
+      );
+
+      const program = Effect.gen(function* () {
+        const service = yield* PortalService;
+        return yield* service.getMemberDashboard('user_123');
+      });
+
+      const result = await Effect.runPromise(
+        Effect.provide(Effect.provide(program, PortalServiceLive), testLayer),
+      );
+
+      expect(result.membership?.status).toBe('expired');
+      expect(result.membership?.daysRemaining).toBe(0);
+      expect(result.canManageSubscription).toBe(false);
+    });
+
     it('should set canManageSubscription based on stripeCustomerId', async () => {
       const mockUserWithStripe = createMockUserDocument({
         stripeCustomerId: 'cus_123',

--- a/src/__tests__/services/renewal-reminders.test.ts
+++ b/src/__tests__/services/renewal-reminders.test.ts
@@ -1,0 +1,86 @@
+import {Effect, Layer} from 'effect';
+import {describe, expect, it, vi} from 'vitest';
+
+import {DatabaseService} from '@/src/lib/effect/database.service';
+import {EmailService} from '@/src/lib/effect/email.service';
+import {sendScheduledRenewalReminders} from '@/src/lib/effect/renewal-reminders';
+
+import {createTestDatabaseService, createTestEmailService} from '../layers/test-layers';
+
+describe('sendScheduledRenewalReminders', () => {
+  it('sends only 30/60/90 day reminders', async () => {
+    const now = new Date();
+    const in30Days = new Date(now);
+    in30Days.setDate(now.getDate() + 30);
+    const in31Days = new Date(now);
+    in31Days.setDate(now.getDate() + 31);
+
+    const databaseService = createTestDatabaseService({
+      getExpiringMemberships: vi.fn(() =>
+        Effect.succeed([
+          {
+            user: {
+              id: 'user_30',
+              email: 'thirty@example.com',
+              name: 'Thirty',
+              createdAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+            },
+            membership: {
+              id: 'mem_30',
+              stripeSubscriptionId: 'sub_30',
+              planType: 'individual' as const,
+              status: 'active' as const,
+              startDate: now.toISOString(),
+              endDate: in30Days.toISOString(),
+              autoRenew: false,
+              createdAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+            },
+            card: null,
+          },
+          {
+            user: {
+              id: 'user_31',
+              email: 'thirtyone@example.com',
+              name: 'Thirty One',
+              createdAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+            },
+            membership: {
+              id: 'mem_31',
+              stripeSubscriptionId: 'sub_31',
+              planType: 'family' as const,
+              status: 'active' as const,
+              startDate: now.toISOString(),
+              endDate: in31Days.toISOString(),
+              autoRenew: false,
+              createdAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+            },
+            card: null,
+          },
+        ]),
+      ),
+    });
+    const emailService = createTestEmailService();
+    const layer = Layer.mergeAll(
+      Layer.succeed(DatabaseService, databaseService),
+      Layer.succeed(EmailService, emailService),
+    );
+
+    const result = await Effect.runPromise(
+      sendScheduledRenewalReminders.pipe(Effect.provide(layer)),
+    );
+
+    expect(result.sent).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(emailService.sendRenewalEmail).toHaveBeenCalledTimes(1);
+    expect(emailService.sendRenewalEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'thirty@example.com',
+        daysUntilExpiration: 30,
+      }),
+    );
+  });
+});

--- a/src/components/admin/EditMemberModal.tsx
+++ b/src/components/admin/EditMemberModal.tsx
@@ -242,6 +242,9 @@ export function EditMemberModal({open, member, onClose}: EditMemberModalProps) {
                   onChange={(e) => handleInputChange('status', e.target.value)}
                 >
                   <MenuItem value="active">Active</MenuItem>
+                  <MenuItem value="expired" disabled>
+                    Expired (based on end date)
+                  </MenuItem>
                   <MenuItem value="past_due">Past Due</MenuItem>
                   <MenuItem value="canceled">Canceled</MenuItem>
                   <MenuItem value="incomplete">Incomplete</MenuItem>

--- a/src/components/admin/MemberTable.tsx
+++ b/src/components/admin/MemberTable.tsx
@@ -8,6 +8,7 @@ import {
   Payment,
   NavigateBefore,
   NavigateNext,
+  MarkEmailUnread,
 } from '@mui/icons-material';
 import {
   Table,
@@ -42,6 +43,7 @@ interface MemberTableProps {
   onViewAudit?: (member: MemberWithMembership) => void;
   onViewPayments?: (member: MemberWithMembership) => void;
   onSendPasswordReset?: (member: MemberWithMembership) => void;
+  onSendRenewalEmail?: (member: MemberWithMembership) => void;
 }
 
 const statusColors: Record<string, 'success' | 'warning' | 'error' | 'default'> = {
@@ -70,6 +72,7 @@ export function MemberTable({
   onViewAudit,
   onViewPayments,
   onSendPasswordReset,
+  onSendRenewalEmail,
 }: MemberTableProps) {
   const totalPages = Math.ceil(total / pageSize);
 
@@ -143,6 +146,17 @@ export function MemberTable({
                             onClick={() => onSendPasswordReset(member)}
                           >
                             <LockReset fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                      {onSendRenewalEmail && (
+                        <Tooltip title="Send Renewal Email">
+                          <IconButton
+                            size="small"
+                            color="info"
+                            onClick={() => onSendRenewalEmail(member)}
+                          >
+                            <MarkEmailUnread fontSize="small" />
                           </IconButton>
                         </Tooltip>
                       )}

--- a/src/components/admin/MembershipManagement.tsx
+++ b/src/components/admin/MembershipManagement.tsx
@@ -20,7 +20,13 @@ import {Effect} from 'effect';
 import {useState} from 'react';
 
 import type {StaffRole} from '@/src/lib/access-control';
-import {refreshStats, getStats, getMembers, sendPasswordReset} from '@/src/lib/effect/client-admin';
+import {
+  refreshStats,
+  getStats,
+  getMembers,
+  sendPasswordReset,
+  sendRenewalEmail,
+} from '@/src/lib/effect/client-admin';
 import type {
   AdminError,
   DatabaseError,
@@ -130,6 +136,20 @@ export function MembershipManagement({role}: {role: StaffRole}) {
       setResetEmailFeedback({message: 'Password reset email sent.', severity: 'success'}),
     onError: (err) =>
       setResetEmailFeedback({message: err.message || 'Failed to send email.', severity: 'error'}),
+  });
+
+  const renewalEmailMutation = useMutation<
+    void,
+    AdminError | EmailError | UnauthorizedError,
+    string
+  >({
+    mutationFn: (userId) => Effect.runPromise(sendRenewalEmail(userId)),
+    onSuccess: () => setResetEmailFeedback({message: 'Renewal email sent.', severity: 'success'}),
+    onError: (err) =>
+      setResetEmailFeedback({
+        message: err.message || 'Failed to send renewal email.',
+        severity: 'error',
+      }),
   });
 
   // Export members
@@ -308,6 +328,7 @@ export function MembershipManagement({role}: {role: StaffRole}) {
                 >
                   <MenuItem value="">All Statuses</MenuItem>
                   <MenuItem value="active">Active</MenuItem>
+                  <MenuItem value="expired">Expired</MenuItem>
                   <MenuItem value="past_due">Past Due</MenuItem>
                   <MenuItem value="canceled">Canceled</MenuItem>
                   <MenuItem value="incomplete">Incomplete</MenuItem>
@@ -392,6 +413,11 @@ export function MembershipManagement({role}: {role: StaffRole}) {
             onViewPayments={isAdmin ? (member) => setPaymentHistoryMember(member) : undefined}
             onSendPasswordReset={(member) =>
               member.user?.id && passwordResetMutation.mutate(member.user.id)
+            }
+            onSendRenewalEmail={
+              isAdmin
+                ? (member) => member.user?.id && renewalEmailMutation.mutate(member.user.id)
+                : undefined
             }
           />
         )}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -7,7 +7,11 @@ import Link from 'next/link';
 import {useRouter} from 'next/navigation';
 import {useState, useEffect} from 'react';
 
-import {getCurrentAccessRole, loginWithPassword, sendMagicLink} from '@/src/lib/effect/client-auth';
+import {
+  getPostLoginRedirectPath,
+  loginWithPassword,
+  sendMagicLink,
+} from '@/src/lib/effect/client-auth';
 import type {AuthError} from '@/src/lib/effect/errors';
 import {auth} from '@/src/utils/firebase';
 
@@ -56,8 +60,8 @@ export function LoginForm() {
           if (response.ok) {
             const data = await response.json();
             if (data.authenticated) {
-              const role = await Effect.runPromise(getCurrentAccessRole());
-              router.replace(role === 'member' ? '/member' : '/dashboard');
+              const redirectPath = await Effect.runPromise(getPostLoginRedirectPath());
+              router.replace(redirectPath);
             }
           }
         } catch {
@@ -73,8 +77,8 @@ export function LoginForm() {
   const loginMutation = useMutation<unknown, AuthError, LoginCredentials>({
     mutationFn: (credentials) => Effect.runPromise(loginWithPassword(credentials)),
     onSuccess: async () => {
-      const role = await Effect.runPromise(getCurrentAccessRole());
-      router.replace(role === 'member' ? '/member' : '/dashboard');
+      const redirectPath = await Effect.runPromise(getPostLoginRedirectPath());
+      router.replace(redirectPath);
     },
   });
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -34,7 +34,7 @@ export function LoginForm() {
       if (hasFirebaseActionParams) {
         // Firebase redirected us here with auth parameters
         // Forward to the verify page to handle the magic link
-        router.push(`/verify${window.location.search}`);
+        router.replace(`/verify${window.location.search}`);
         return;
       }
 
@@ -44,7 +44,7 @@ export function LoginForm() {
 
       if (isMagicLink) {
         // Redirect to verify page to handle the magic link
-        router.push(`/verify${window.location.search}`);
+        router.replace(`/verify${window.location.search}`);
         return;
       }
 
@@ -57,7 +57,7 @@ export function LoginForm() {
             const data = await response.json();
             if (data.authenticated) {
               const role = await Effect.runPromise(getCurrentAccessRole());
-              window.location.href = role === 'member' ? '/member' : '/dashboard';
+              router.replace(role === 'member' ? '/member' : '/dashboard');
             }
           }
         } catch {
@@ -74,7 +74,7 @@ export function LoginForm() {
     mutationFn: (credentials) => Effect.runPromise(loginWithPassword(credentials)),
     onSuccess: async () => {
       const role = await Effect.runPromise(getCurrentAccessRole());
-      window.location.href = role === 'member' ? '/member' : '/dashboard';
+      router.replace(role === 'member' ? '/member' : '/dashboard');
     },
   });
 

--- a/src/components/member/MemberDashboardClient.tsx
+++ b/src/components/member/MemberDashboardClient.tsx
@@ -49,7 +49,7 @@ export function MemberDashboardClient({initialData}: MemberDashboardClientProps)
     queryKey: ['digitalCard'],
     queryFn: () => Effect.runPromise(getDigitalCard()),
     // Only fetch when membership exists and not in error state
-    enabled: !('error' in data) && !!data.membership,
+    enabled: !('error' in data) && !!data.membership && data.membership.status !== 'expired',
     // Refetch when window regains focus (e.g., returning from Stripe)
     refetchOnWindowFocus: true,
     // Don't retry on 401/404 errors
@@ -113,6 +113,7 @@ export function MemberDashboardClient({initialData}: MemberDashboardClientProps)
   }
 
   const {user, membership, canManageSubscription} = data;
+  const currentMembership = membership?.status === 'expired' ? null : membership;
 
   // Show loading state if polling for membership after checkout
   if (isPolling && sessionId) {
@@ -131,148 +132,188 @@ export function MemberDashboardClient({initialData}: MemberDashboardClientProps)
 
   return (
     <Box className="dec-page" sx={{minHeight: '100vh'}}>
-    <Container maxWidth="lg" sx={{py: {xs: 5, md: 8}}}>
-      {/* Success message after checkout */}
-      {sessionId && membership && (
-        <Alert severity="success" sx={{mb: 3}}>
-          Welcome! Your membership has been activated successfully.
-        </Alert>
-      )}
-
-      {/* Warning if polling timed out */}
-      {sessionId && !membership && pollAttempts >= 10 && (
-        <Alert severity="warning" sx={{mb: 3}}>
-          Your payment is being processed. If your membership doesn&apos;t appear shortly, please
-          refresh the page or contact support.
-        </Alert>
-      )}
-
-      <Box sx={{mb: 5, display: 'flex', justifyContent: 'space-between', gap: 3, flexDirection: {xs: 'column', md: 'row'}}}>
-        <Box>
-          <Typography variant="overline" sx={{color: '#F20E02', fontWeight: 800, letterSpacing: '.1em'}}>
-            MEMBER PORTAL
-          </Typography>
-          <Typography variant="h1" sx={{fontSize: {xs: 54, md: 86}, lineHeight: .9}}>
-            Welcome back
-          </Typography>
-          <Typography color="text.secondary" sx={{mt: 2, fontSize: 18}}>
-            {user.name || user.email}
-          </Typography>
-        </Box>
-        {membership && (
-          <Chip
-            label={membership.status.replace('_', ' ')}
-            color={membership.status === 'active' ? 'success' : 'warning'}
-            sx={{alignSelf: {xs: 'flex-start', md: 'center'}, fontWeight: 800, borderRadius: 999, px: 1}}
-          />
+      <Container maxWidth="lg" sx={{py: {xs: 5, md: 8}}}>
+        {/* Success message after checkout */}
+        {sessionId && membership && (
+          <Alert severity="success" sx={{mb: 3}}>
+            Welcome! Your membership has been activated successfully.
+          </Alert>
         )}
-      </Box>
 
-      {membership ? (
-        <Box sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', lg: '.9fr 1.1fr'}, gap: 3, alignItems: 'start'}}>
-          <Box sx={{display: 'grid', gap: 3}}>
-            <Paper className="dec-card" sx={{p: 3}}>
-              <Typography variant="h4" component="h2" sx={{mb: 2}}>
-                Account details
+        {/* Warning if polling timed out */}
+        {sessionId && !membership && pollAttempts >= 10 && (
+          <Alert severity="warning" sx={{mb: 3}}>
+            Your payment is being processed. If your membership doesn&apos;t appear shortly, please
+            refresh the page or contact support.
+          </Alert>
+        )}
+
+        <Box
+          sx={{
+            mb: 5,
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: 3,
+            flexDirection: {xs: 'column', md: 'row'},
+          }}
+        >
+          <Box>
+            <Typography
+              variant="overline"
+              sx={{color: '#F20E02', fontWeight: 800, letterSpacing: '.1em'}}
+            >
+              MEMBER PORTAL
+            </Typography>
+            <Typography variant="h1" sx={{fontSize: {xs: 54, md: 86}, lineHeight: 0.9}}>
+              Welcome back
+            </Typography>
+            <Typography color="text.secondary" sx={{mt: 2, fontSize: 18}}>
+              {user.name || user.email}
+            </Typography>
+          </Box>
+          {membership && (
+            <Chip
+              label={membership.status.replace('_', ' ')}
+              color={
+                membership.status === 'expired'
+                  ? 'error'
+                  : membership.status === 'active'
+                    ? 'success'
+                    : 'warning'
+              }
+              sx={{
+                alignSelf: {xs: 'flex-start', md: 'center'},
+                fontWeight: 800,
+                borderRadius: 999,
+                px: 1,
+              }}
+            />
+          )}
+        </Box>
+
+        {currentMembership ? (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {xs: '1fr', lg: '.9fr 1.1fr'},
+              gap: 3,
+              alignItems: 'start',
+            }}
+          >
+            <Box sx={{display: 'grid', gap: 3}}>
+              <Paper className="dec-card" sx={{p: 3}}>
+                <Typography variant="h4" component="h2" sx={{mb: 2}}>
+                  Account details
+                </Typography>
+                <Box sx={{display: 'grid', gap: 1.5}}>
+                  <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
+                    <Typography color="text.secondary">Name</Typography>
+                    <Typography fontWeight={700}>{user.name || 'Not set'}</Typography>
+                  </Box>
+                  <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
+                    <Typography color="text.secondary">Email</Typography>
+                    <Typography fontWeight={700}>{user.email}</Typography>
+                  </Box>
+                  <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
+                    <Typography color="text.secondary">Plan</Typography>
+                    <Typography fontWeight={700}>{currentMembership.planName}</Typography>
+                  </Box>
+                  <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
+                    <Typography color="text.secondary">Renews</Typography>
+                    <Typography fontWeight={700}>
+                      {new Date(currentMembership.endDate).toLocaleDateString()}
+                    </Typography>
+                  </Box>
+                </Box>
+                <Box sx={{mt: 3, display: 'flex', flexWrap: 'wrap', gap: 1.5}}>
+                  {canManageSubscription && (
+                    <PortalButton
+                      returnUrl={`${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/member`}
+                    />
+                  )}
+                  <Button variant="outlined" disabled>
+                    Edit profile
+                  </Button>
+                </Box>
+              </Paper>
+
+              <MembershipCard membership={currentMembership} />
+
+              <Paper className="dec-card" sx={{p: 3}}>
+                <Typography variant="h4" component="h2" sx={{mb: 2}}>
+                  Quick actions
+                </Typography>
+                <Box
+                  sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', sm: '1fr 1fr'}, gap: 1.5}}
+                >
+                  <Button
+                    component={Link}
+                    href="https://www.meetup.com/down-east-cyclists/events/calendar/"
+                    target="_blank"
+                    variant="outlined"
+                  >
+                    Rides ↗
+                  </Button>
+                  <Button component={Link} href="/trails/b3" variant="outlined">
+                    Trails
+                  </Button>
+                  <Button component={Link} href="/blog" variant="outlined">
+                    News
+                  </Button>
+                  <Button component={Link} href="/contact" variant="outlined">
+                    Help
+                  </Button>
+                </Box>
+              </Paper>
+            </Box>
+
+            <Paper className="dec-card" sx={{p: {xs: 2, md: 4}}}>
+              <Typography variant="h4" component="h2" sx={{mb: 1}}>
+                Digital membership card
               </Typography>
-              <Box sx={{display: 'grid', gap: 1.5}}>
-                <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
-                  <Typography color="text.secondary">Name</Typography>
-                  <Typography fontWeight={700}>{user.name || 'Not set'}</Typography>
-                </Box>
-                <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
-                  <Typography color="text.secondary">Email</Typography>
-                  <Typography fontWeight={700}>{user.email}</Typography>
-                </Box>
-                <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
-                  <Typography color="text.secondary">Plan</Typography>
-                  <Typography fontWeight={700}>{membership.planName}</Typography>
-                </Box>
-                <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
-                  <Typography color="text.secondary">Renews</Typography>
-                  <Typography fontWeight={700}>{new Date(membership.endDate).toLocaleDateString()}</Typography>
-                </Box>
-              </Box>
-              <Box sx={{mt: 3, display: 'flex', flexWrap: 'wrap', gap: 1.5}}>
-                {canManageSubscription && (
-                  <PortalButton
-                    returnUrl={`${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/member`}
-                  />
-                )}
-                <Button variant="outlined" disabled>
-                  Edit profile
-                </Button>
-              </Box>
-            </Paper>
-
-            <MembershipCard membership={membership} />
-
-            <Paper className="dec-card" sx={{p: 3}}>
-              <Typography variant="h4" component="h2" sx={{mb: 2}}>
-                Quick actions
+              <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
+                Show this QR code to verify your membership at events and partner locations.
               </Typography>
-              <Box sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', sm: '1fr 1fr'}, gap: 1.5}}>
-                <Button component={Link} href="https://www.meetup.com/down-east-cyclists/events/calendar/" target="_blank" variant="outlined">
-                  Rides ↗
-                </Button>
-                <Button component={Link} href="/trails/b3" variant="outlined">
-                  Trails
-                </Button>
-                <Button component={Link} href="/blog" variant="outlined">
-                  News
-                </Button>
-                <Button component={Link} href="/contact" variant="outlined">
-                  Help
-                </Button>
-              </Box>
+              {cardQuery.isLoading ? (
+                <DigitalCard card={{} as MembershipCardSchema} loading />
+              ) : cardQuery.data?.hasCard && cardQuery.data.card ? (
+                <DigitalCard card={cardQuery.data.card} />
+              ) : cardQuery.error ? (
+                <Paper sx={{p: 3, textAlign: 'center'}}>
+                  <Typography color="error">{cardQuery.error.message}</Typography>
+                  <Button variant="text" onClick={() => cardQuery.refetch()} sx={{mt: 1}}>
+                    Try Again
+                  </Button>
+                </Paper>
+              ) : (
+                <Paper sx={{p: 3, textAlign: 'center'}}>
+                  <Typography color="text.secondary">
+                    Your digital membership card is being generated. This usually takes a few
+                    moments after checkout.
+                  </Typography>
+                  <Button variant="text" onClick={() => cardQuery.refetch()} sx={{mt: 1}}>
+                    Check Again
+                  </Button>
+                </Paper>
+              )}
             </Paper>
           </Box>
-
-          <Paper className="dec-card" sx={{p: {xs: 2, md: 4}}}>
-            <Typography variant="h4" component="h2" sx={{mb: 1}}>
-              Digital membership card
+        ) : (
+          <Paper sx={{p: 3, textAlign: 'center'}}>
+            <Typography variant="h6" gutterBottom>
+              {membership?.status === 'expired' ? 'Membership Expired' : 'No Active Membership'}
             </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{mb: 3}}>
-              Show this QR code to verify your membership at events and partner locations.
+            <Typography color="text.secondary" sx={{mb: 2}}>
+              {membership?.status === 'expired'
+                ? 'Renew your membership to restore your digital card and member benefits.'
+                : 'You don&apos;t have an active membership yet.'}
             </Typography>
-            {cardQuery.isLoading ? (
-              <DigitalCard card={{} as MembershipCardSchema} loading />
-            ) : cardQuery.data?.hasCard && cardQuery.data.card ? (
-              <DigitalCard card={cardQuery.data.card} />
-            ) : cardQuery.error ? (
-              <Paper sx={{p: 3, textAlign: 'center'}}>
-                <Typography color="error">{cardQuery.error.message}</Typography>
-                <Button variant="text" onClick={() => cardQuery.refetch()} sx={{mt: 1}}>
-                  Try Again
-                </Button>
-              </Paper>
-            ) : (
-              <Paper sx={{p: 3, textAlign: 'center'}}>
-                <Typography color="text.secondary">
-                  Your digital membership card is being generated. This usually takes a few moments
-                  after checkout.
-                </Typography>
-                <Button variant="text" onClick={() => cardQuery.refetch()} sx={{mt: 1}}>
-                  Check Again
-                </Button>
-              </Paper>
-            )}
+            <Button component={Link} href="/renew" variant="contained" color="primary">
+              Renew Membership
+            </Button>
           </Paper>
-        </Box>
-      ) : (
-        <Paper sx={{p: 3, textAlign: 'center'}}>
-          <Typography variant="h6" gutterBottom>
-            No Active Membership
-          </Typography>
-          <Typography color="text.secondary" sx={{mb: 2}}>
-            You don&apos;t have an active membership yet.
-          </Typography>
-          <Button component={Link} href="/join" variant="contained" color="primary">
-            View Membership Plans
-          </Button>
-        </Paper>
-      )}
-    </Container>
+        )}
+      </Container>
     </Box>
   );
 }

--- a/src/components/member/MembershipCard.tsx
+++ b/src/components/member/MembershipCard.tsx
@@ -16,6 +16,7 @@ const statusColors: Record<string, 'success' | 'warning' | 'error' | 'default'> 
   incomplete: 'warning',
   incomplete_expired: 'error',
   unpaid: 'error',
+  expired: 'error',
 };
 
 export function MembershipCard({membership}: MembershipCardProps) {

--- a/src/components/membership/RenewMembershipClient.tsx
+++ b/src/components/membership/RenewMembershipClient.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  Grid,
+  Paper,
+  Typography,
+} from '@mui/material';
+import {useMutation, useQuery} from '@tanstack/react-query';
+import {useEffect, useState} from 'react';
+
+import {PlanCard, type MembershipPlan} from './PlanCard';
+
+interface RenewMembershipClientProps {
+  userId: string;
+  email: string;
+  name: string | null;
+  canceled: boolean;
+  expiredOn?: string;
+}
+
+interface CheckoutResponse {
+  url: string;
+}
+
+export function RenewMembershipClient({
+  userId,
+  email,
+  name,
+  canceled,
+  expiredOn,
+}: RenewMembershipClientProps) {
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+  const [selectedPriceId, setSelectedPriceId] = useState<string | null>(null);
+  const [selectedPlanPrice, setSelectedPlanPrice] = useState(0);
+  const [coverFees, setCoverFees] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const plansQuery = useQuery<MembershipPlan[]>({
+    queryKey: ['membership-plans'],
+    queryFn: async () => {
+      const response = await fetch('/api/membership/plans');
+      if (!response.ok) {
+        throw new Error('Failed to fetch membership plans');
+      }
+      return response.json();
+    },
+  });
+
+  const checkoutMutation = useMutation<CheckoutResponse, Error, void>({
+    mutationFn: async () => {
+      if (!selectedPriceId) {
+        throw new Error('Please select a membership plan');
+      }
+
+      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin;
+      const response = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          priceId: selectedPriceId,
+          userId,
+          email,
+          successUrl: `${siteUrl}/member?session_id={CHECKOUT_SESSION_ID}`,
+          cancelUrl: `${siteUrl}/renew?canceled=true`,
+          coverFees,
+          planPrice: selectedPlanPrice,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to start renewal');
+      }
+
+      return response.json();
+    },
+    onSuccess: (checkout) => {
+      window.location.href = checkout.url;
+    },
+  });
+
+  const handlePlanSelect = (planId: string, stripePriceId: string) => {
+    setSelectedPlanId(planId);
+    setSelectedPriceId(stripePriceId);
+    setSelectedPlanPrice(plansQuery.data?.find((plan) => plan.id === planId)?.price || 0);
+    setValidationError(null);
+  };
+
+  useEffect(() => {
+    if (!plansQuery.data?.length || selectedPlanId) return;
+    const currentPlan = plansQuery.data[0];
+    handlePlanSelect(currentPlan.id, currentPlan.stripePriceId);
+  }, [plansQuery.data, selectedPlanId]);
+
+  const processingFee = selectedPlanPrice > 0 ? selectedPlanPrice * 0.027 + 0.05 : 0;
+  const errorMessage = validationError || checkoutMutation.error?.message || null;
+
+  const handleSubmit = () => {
+    if (!selectedPriceId) {
+      setValidationError('Please select a membership plan');
+      return;
+    }
+    checkoutMutation.mutate();
+  };
+
+  return (
+    <Box sx={{display: 'grid', gridTemplateColumns: {xs: '1fr', lg: '1.1fr .9fr'}, gap: 3}}>
+      <Box>
+        {canceled && (
+          <Alert severity="info" sx={{mb: 3}}>
+            Your renewal payment was canceled. You can try again below.
+          </Alert>
+        )}
+
+        {errorMessage && (
+          <Alert severity="error" sx={{mb: 3}}>
+            {errorMessage}
+          </Alert>
+        )}
+
+        {plansQuery.isLoading && (
+          <Box sx={{display: 'flex', justifyContent: 'center', py: 4}}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {plansQuery.error && (
+          <Alert severity="error" sx={{mb: 3}}>
+            Failed to load membership plans. Please try again later.
+          </Alert>
+        )}
+
+        {plansQuery.data && (
+          <Grid container spacing={3}>
+            {plansQuery.data.map((plan) => (
+              <Grid item xs={12} sm={6} key={plan.id}>
+                <PlanCard
+                  plan={plan}
+                  selected={selectedPlanId === plan.id}
+                  onSelect={handlePlanSelect}
+                  disabled={checkoutMutation.isPending}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        )}
+      </Box>
+
+      <Paper className="dec-card" sx={{p: {xs: 3, md: 4}, alignSelf: 'start'}}>
+        <Typography variant="h4" component="h2" gutterBottom>
+          Renewal
+        </Typography>
+        <Box sx={{display: 'grid', gap: 1.5, my: 3}}>
+          <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
+            <Typography color="text.secondary">Account</Typography>
+            <Typography fontWeight={700}>{name || email}</Typography>
+          </Box>
+          {expiredOn && (
+            <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
+              <Typography color="text.secondary">Expired</Typography>
+              <Typography fontWeight={700}>{new Date(expiredOn).toLocaleDateString()}</Typography>
+            </Box>
+          )}
+          <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
+            <Typography color="text.secondary">Selected plan</Typography>
+            <Typography fontWeight={700}>
+              {selectedPlanPrice > 0 ? `$${selectedPlanPrice.toFixed(2)}` : '-'}
+            </Typography>
+          </Box>
+        </Box>
+
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={coverFees}
+              onChange={(event) => setCoverFees(event.target.checked)}
+              disabled={checkoutMutation.isPending}
+            />
+          }
+          label={`Add ${processingFee > 0 ? `$${processingFee.toFixed(2)}` : 'processing fees'} to help cover card fees`}
+        />
+
+        <Button
+          fullWidth
+          variant="contained"
+          size="large"
+          onClick={handleSubmit}
+          disabled={checkoutMutation.isPending || plansQuery.isLoading}
+          sx={{mt: 3}}
+        >
+          {checkoutMutation.isPending ? 'Starting renewal...' : 'Renew with Stripe'}
+        </Button>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -1,3 +1,5 @@
+import {isCurrentMembershipStatus} from './membership-status';
+
 export type AccessRole = 'member' | 'organizer' | 'admin';
 
 export type StaffRole = Exclude<AccessRole, 'member'>;
@@ -70,7 +72,5 @@ export function hasCurrentMembership(
     return false;
   }
 
-  const endDate =
-    membership.endDate instanceof Date ? membership.endDate : new Date(String(membership.endDate));
-  return !Number.isNaN(endDate.getTime()) && endDate >= now;
+  return isCurrentMembershipStatus(membership?.status, membership?.endDate, now);
 }

--- a/src/lib/effect/admin.service.ts
+++ b/src/lib/effect/admin.service.ts
@@ -7,6 +7,12 @@ import {
   hasCurrentMembership,
   hasDashboardCapability,
 } from '@/src/lib/access-control';
+import {getPlanNameForType} from '@/src/lib/membership-plans-config';
+import {
+  getMembershipDaysUntilExpiration,
+  isCurrentMembershipStatus,
+  parseMembershipDate,
+} from '@/src/lib/membership-status';
 import {isPrimaryAdminEmail} from '@/src/lib/primary-admin';
 import type {
   AuditEntry,
@@ -174,6 +180,12 @@ export interface AdminService {
   readonly sendPasswordReset: (
     userId: string,
   ) => Effect.Effect<void, MemberNotFoundError | DatabaseError | AuthError | EmailError>;
+
+  readonly sendRenewalEmail: (
+    userId: string,
+    adminUid: string,
+    adminEmail?: string,
+  ) => Effect.Effect<void, MemberNotFoundError | DatabaseError | EmailError>;
 }
 
 // Service tag
@@ -216,6 +228,15 @@ function describeStripeError(error: StripeError): string {
         : undefined;
 
   return causeMessage ? `${error.message}: ${causeMessage}` : error.message;
+}
+
+function getSiteUrl() {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.SITE_URL ||
+    process.env.URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
 }
 
 function getSubscriptionPeriodDates(subscription: Stripe.Subscription): {
@@ -1447,6 +1468,47 @@ const make = Effect.gen(function* () {
           to: user.email,
           name: user.name,
           passwordSetupLink: resetLink,
+        });
+      }),
+
+    sendRenewalEmail: (userId, adminUid, adminEmail) =>
+      Effect.gen(function* () {
+        const user = yield* db.getUser(userId);
+        if (!user) {
+          return yield* new MemberNotFoundError({
+            userId,
+            message: 'Member not found',
+          });
+        }
+
+        const membership = yield* db.getActiveMembership(userId);
+        const renewalUrl = `${getSiteUrl()}/renew`;
+        const endDate = membership ? parseMembershipDate(membership.endDate) : null;
+        const daysUntilExpiration = membership
+          ? getMembershipDaysUntilExpiration(membership.endDate)
+          : null;
+        const reminderDays =
+          daysUntilExpiration === 30 || daysUntilExpiration === 60 || daysUntilExpiration === 90
+            ? daysUntilExpiration
+            : undefined;
+
+        yield* emailService.sendRenewalEmail({
+          to: user.email,
+          name: user.name,
+          renewalUrl,
+          expirationDate: endDate?.toISOString(),
+          planName: membership ? getPlanNameForType(membership.planType) : undefined,
+          daysUntilExpiration: isCurrentMembershipStatus(membership?.status, membership?.endDate)
+            ? reminderDays
+            : undefined,
+          idempotencyKey: `admin-renewal/${user.id}/${new Date().toISOString().slice(0, 10)}`,
+        });
+
+        yield* db.logAuditEntry(userId, 'MEMBERSHIP_ADJUSTMENT', {
+          performedBy: adminUid,
+          performedByEmail: adminEmail,
+          action: 'RENEWAL_EMAIL_SENT',
+          timestamp: new Date().toISOString(),
         });
       }),
   });

--- a/src/lib/effect/client-admin.ts
+++ b/src/lib/effect/client-admin.ts
@@ -459,6 +459,40 @@ export const sendPasswordReset = (
   });
 
 /**
+ * Send a renewal email to an existing member
+ */
+export const sendRenewalEmail = (
+  userId: string,
+): Effect.Effect<void, AdminError | EmailError | UnauthorizedError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(`/api/admin/members/${userId}/renewal-email`, {
+        method: 'POST',
+      });
+
+      if (response.status === 401 || response.status === 403) {
+        const data = await response.json();
+        throw new UnauthorizedError({message: data.error || 'Unauthorized'});
+      }
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to send renewal email');
+      }
+    },
+    catch: (error) => {
+      if (error instanceof UnauthorizedError) {
+        return error;
+      }
+      return new AdminError({
+        code: 'SEND_RENEWAL_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to send renewal email',
+        cause: error,
+      });
+    },
+  });
+
+/**
  * Issue a refund for a payment
  */
 export const issueRefund = (

--- a/src/lib/effect/client-auth.ts
+++ b/src/lib/effect/client-auth.ts
@@ -48,6 +48,43 @@ export const getCurrentAccessRole = (): Effect.Effect<AccessRole, AuthError> =>
       }),
   });
 
+export const getPostLoginRedirectPath = (): Effect.Effect<string, AuthError> =>
+  Effect.gen(function* () {
+    const role = yield* getCurrentAccessRole();
+    if (role !== 'member') {
+      return '/dashboard';
+    }
+
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetch('/api/member/dashboard');
+        if (!response.ok) return '/member';
+
+        const data = await response.json();
+        if (
+          typeof data === 'object' &&
+          data !== null &&
+          'membership' in data &&
+          (!data.membership ||
+            (typeof data.membership === 'object' &&
+              data.membership !== null &&
+              'status' in data.membership &&
+              data.membership.status === 'expired'))
+        ) {
+          return '/renew';
+        }
+
+        return '/member';
+      },
+      catch: (error) =>
+        new AuthError({
+          code: 'POST_LOGIN_REDIRECT_FAILED',
+          message: 'Failed to determine where to send you after login',
+          cause: error,
+        }),
+    });
+  });
+
 // Sign in with email/password
 export const signInWithPassword = (
   credentials: LoginCredentials,

--- a/src/lib/effect/database-card.methods.ts
+++ b/src/lib/effect/database-card.methods.ts
@@ -2,10 +2,11 @@ import {eq, sql} from 'drizzle-orm';
 import {Effect} from 'effect';
 
 import {membershipCards, membershipCounters, memberships, users} from '@/src/db/schema/tables';
+import {getEffectiveMembershipStatus, toStoredMembershipStatus} from '@/src/lib/membership-status';
 
 import {resolveUserId} from './database.service';
 import {DatabaseError} from './errors';
-import type {MembershipCard, MembershipStatus} from './schemas';
+import type {MembershipCard} from './schemas';
 
 // Lazy db loader — avoids triggering Neon connection at import time
 function getDb() {
@@ -24,7 +25,7 @@ function rowToCardDocument(row: typeof membershipCards.$inferSelect): Membership
     memberName: row.memberName,
     email: row.email,
     planType: row.planType,
-    status: row.status as MembershipStatus,
+    status: getEffectiveMembershipStatus(row.status, row.validUntil),
     validFrom: row.validFrom.toISOString(),
     validUntil: row.validUntil.toISOString(),
     qrCodeData: row.qrCodeData,
@@ -91,7 +92,7 @@ export function createCardMethods() {
                   memberName: card.memberName,
                   email: card.email,
                   planType: card.planType,
-                  status: card.status,
+                  status: toStoredMembershipStatus(card.status),
                   validFrom: new Date(card.validFrom),
                   validUntil: new Date(card.validUntil),
                   qrCodeData: card.qrCodeData,
@@ -122,7 +123,7 @@ export function createCardMethods() {
                 memberName: card.memberName,
                 email: card.email,
                 planType: card.planType,
-                status: card.status,
+                status: toStoredMembershipStatus(card.status),
                 validFrom: new Date(card.validFrom),
                 validUntil: new Date(card.validUntil),
                 qrCodeData: card.qrCodeData,
@@ -156,7 +157,7 @@ export function createCardMethods() {
             if (data.memberName !== undefined) updates.memberName = data.memberName;
             if (data.email !== undefined) updates.email = data.email;
             if (data.planType !== undefined) updates.planType = data.planType;
-            if (data.status !== undefined) updates.status = data.status;
+            if (data.status !== undefined) updates.status = toStoredMembershipStatus(data.status);
             if (data.validFrom !== undefined) updates.validFrom = new Date(data.validFrom);
             if (data.validUntil !== undefined) updates.validUntil = new Date(data.validUntil);
             if (data.qrCodeData !== undefined) updates.qrCodeData = data.qrCodeData;

--- a/src/lib/effect/database-membership.methods.ts
+++ b/src/lib/effect/database-membership.methods.ts
@@ -1,7 +1,8 @@
-import {and, desc, eq, gte, ilike, inArray, lte, or, sql} from 'drizzle-orm';
+import {and, desc, eq, gte, ilike, inArray, lt, lte, or, sql} from 'drizzle-orm';
 import {Effect} from 'effect';
 
 import {membershipCards, memberships, users} from '@/src/db/schema/tables';
+import {getEffectiveMembershipStatus, toStoredMembershipStatus} from '@/src/lib/membership-status';
 
 import {resolveUserId} from './database.service';
 import {DatabaseError} from './errors';
@@ -9,7 +10,6 @@ import type {
   MemberSearchParams,
   MemberWithMembership,
   MembershipDocument,
-  MembershipStatus,
   UserDocument,
 } from './schemas';
 
@@ -22,13 +22,39 @@ function getDb() {
 // Helpers
 // ---------------------------------------------------------------------------
 
+type DatabaseMembershipStatus = typeof memberships.$inferSelect.status;
+
+const currentDatabaseStatuses: DatabaseMembershipStatus[] = [
+  'active',
+  'trialing',
+  'past_due',
+  'complimentary',
+  'legacy',
+];
+
+const databaseStatuses: ReadonlySet<string> = new Set([
+  ...currentDatabaseStatuses,
+  'canceled',
+  'incomplete',
+  'incomplete_expired',
+  'unpaid',
+  'deleted',
+]);
+
+function isDatabaseMembershipStatus(status: string): status is DatabaseMembershipStatus {
+  return databaseStatuses.has(status);
+}
+
 /** Maps a Postgres membership row to the MembershipDocument schema shape. */
-function rowToMembershipDocument(row: typeof memberships.$inferSelect): MembershipDocument {
+function rowToMembershipDocument(
+  row: typeof memberships.$inferSelect,
+  now: Date = new Date(),
+): MembershipDocument {
   return {
     id: row.id,
     stripeSubscriptionId: row.stripeSubscriptionId ?? '',
     planType: row.planType,
-    status: row.status as MembershipStatus,
+    status: getEffectiveMembershipStatus(row.status, row.endDate, now),
     startDate: row.startDate.toISOString(),
     endDate: row.endDate.toISOString(),
     autoRenew: row.autoRenew,
@@ -58,7 +84,7 @@ function rowToUserDocument(row: typeof users.$inferSelect): UserDocument {
 }
 
 /** Maps a Postgres membership card row to the MembershipCard schema shape. */
-function rowToCardDocument(row: typeof membershipCards.$inferSelect) {
+function rowToCardDocument(row: typeof membershipCards.$inferSelect, now: Date = new Date()) {
   return {
     id: row.id,
     userId: row.userId,
@@ -66,7 +92,7 @@ function rowToCardDocument(row: typeof membershipCards.$inferSelect) {
     memberName: row.memberName,
     email: row.email,
     planType: row.planType,
-    status: row.status as MembershipStatus,
+    status: getEffectiveMembershipStatus(row.status, row.validUntil, now),
     validFrom: row.validFrom.toISOString(),
     validUntil: row.validUntil.toISOString(),
     qrCodeData: row.qrCodeData,
@@ -171,7 +197,7 @@ export function createMembershipMethods() {
                 .update(memberships)
                 .set({
                   planType: data.planType,
-                  status: data.status,
+                  status: toStoredMembershipStatus(data.status),
                   startDate: new Date(data.startDate as string),
                   endDate: new Date(data.endDate as string),
                   autoRenew: data.autoRenew,
@@ -183,7 +209,7 @@ export function createMembershipMethods() {
                 userId: userRow.id,
                 stripeSubscriptionId: subId,
                 planType: data.planType,
-                status: data.status,
+                status: toStoredMembershipStatus(data.status),
                 startDate: new Date(data.startDate as string),
                 endDate: new Date(data.endDate as string),
                 autoRenew: data.autoRenew,
@@ -214,7 +240,7 @@ export function createMembershipMethods() {
             if (data.stripeSubscriptionId !== undefined)
               updates.stripeSubscriptionId = data.stripeSubscriptionId || null;
             if (data.planType !== undefined) updates.planType = data.planType;
-            if (data.status !== undefined) updates.status = data.status;
+            if (data.status !== undefined) updates.status = toStoredMembershipStatus(data.status);
             if (data.startDate !== undefined)
               updates.startDate = new Date(data.startDate as string);
             if (data.endDate !== undefined) updates.endDate = new Date(data.endDate as string);
@@ -254,10 +280,19 @@ export function createMembershipMethods() {
     getAllMemberships: (params: MemberSearchParams) =>
       Effect.tryPromise({
         try: async () => {
+          const now = new Date();
           const conditions = [];
 
           if (params.status) {
-            conditions.push(eq(memberships.status, params.status));
+            if (params.status === 'expired') {
+              conditions.push(inArray(memberships.status, currentDatabaseStatuses));
+              conditions.push(lt(memberships.endDate, now));
+            } else if (isDatabaseMembershipStatus(params.status)) {
+              conditions.push(eq(memberships.status, params.status));
+              if (currentDatabaseStatuses.includes(params.status)) {
+                conditions.push(gte(memberships.endDate, now));
+              }
+            }
           }
 
           if (params.planType) {
@@ -267,6 +302,7 @@ export function createMembershipMethods() {
           if (params.expiringWithinDays) {
             const expiryDate = new Date();
             expiryDate.setDate(expiryDate.getDate() + params.expiringWithinDays);
+            conditions.push(gte(memberships.endDate, new Date()));
             conditions.push(lte(memberships.endDate, expiryDate));
           }
 
@@ -316,8 +352,8 @@ export function createMembershipMethods() {
 
           const members: MemberWithMembership[] = rows.map((row) => ({
             user: row.user ? rowToUserDocument(row.user) : null,
-            membership: row.membership ? rowToMembershipDocument(row.membership) : null,
-            card: row.card ? rowToCardDocument(row.card) : null,
+            membership: row.membership ? rowToMembershipDocument(row.membership, now) : null,
+            card: row.card ? rowToCardDocument(row.card, now) : null,
           }));
 
           return {members, total};
@@ -348,7 +384,7 @@ export function createMembershipMethods() {
             .leftJoin(membershipCards, eq(membershipCards.membershipId, memberships.id))
             .where(
               and(
-                inArray(memberships.status, ['active', 'past_due']),
+                inArray(memberships.status, currentDatabaseStatuses),
                 gte(memberships.endDate, now),
                 lte(memberships.endDate, expiryDate),
               ),
@@ -357,8 +393,8 @@ export function createMembershipMethods() {
 
           return rows.map((row) => ({
             user: row.user ? rowToUserDocument(row.user) : null,
-            membership: row.membership ? rowToMembershipDocument(row.membership) : null,
-            card: row.card ? rowToCardDocument(row.card) : null,
+            membership: row.membership ? rowToMembershipDocument(row.membership, now) : null,
+            card: row.card ? rowToCardDocument(row.card, now) : null,
           }));
         },
         catch: (error) =>

--- a/src/lib/effect/email.service.ts
+++ b/src/lib/effect/email.service.ts
@@ -9,6 +9,16 @@ export interface EmailService {
     name: string | undefined;
     passwordSetupLink: string;
   }) => Effect.Effect<void, EmailError>;
+
+  readonly sendRenewalEmail: (params: {
+    to: string;
+    name: string | undefined;
+    renewalUrl: string;
+    expirationDate: string | undefined;
+    planName: string | undefined;
+    daysUntilExpiration?: 30 | 60 | 90;
+    idempotencyKey: string;
+  }) => Effect.Effect<void, EmailError>;
 }
 
 export const EmailService = Context.GenericTag<EmailService>('EmailService');
@@ -21,6 +31,22 @@ const make = Effect.gen(function* () {
 
   const resend = apiKey ? new Resend(apiKey) : null;
   const from = process.env.EMAIL_FROM ?? 'Down East Cyclists <noreply@downeastcyclists.com>';
+  const renewalTemplateId = process.env.RESEND_RENEWAL_TEMPLATE_ID;
+
+  const describeResendError = (error: unknown) =>
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' && error !== null && 'message' in error
+        ? String((error as {message: unknown}).message)
+        : JSON.stringify(error);
+
+  const escapeHtml = (value: string) =>
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
 
   return EmailService.of({
     sendWelcomeEmail: ({to, name, passwordSetupLink}) =>
@@ -36,11 +62,12 @@ const make = Effect.gen(function* () {
 
         yield* Effect.tryPromise({
           try: async () => {
-            const {data, error} = await resend.emails.send({
-              from,
-              to,
-              subject: 'Welcome to Down East Cyclists — Set Your Password',
-              html: `
+            const {data, error} = await resend.emails.send(
+              {
+                from,
+                to,
+                subject: 'Welcome to Down East Cyclists — Set Your Password',
+                html: `
                 <p>Hi ${displayName},</p>
                 <p>Your Down East Cyclists membership account has been created.</p>
                 <p>Click the link below to set your password and access the member portal:</p>
@@ -49,23 +76,114 @@ const make = Effect.gen(function* () {
                    "Forgot password?" option on the sign-in page.</p>
                 <p>— Down East Cyclists</p>
               `.trim(),
-            });
+              },
+              {idempotencyKey: `welcome-email/${to}`},
+            );
             if (error) {
               throw error;
             }
             return data;
           },
           catch: (error) => {
-            const detail =
-              error instanceof Error
-                ? error.message
-                : typeof error === 'object' && error !== null && 'message' in error
-                  ? String((error as {message: unknown}).message)
-                  : JSON.stringify(error);
+            const detail = describeResendError(error);
             console.error('[EmailService] Resend error:', error);
             return new EmailError({
               code: 'SEND_FAILED',
               message: `Failed to send welcome email to ${to}: ${detail}`,
+              cause: error,
+            });
+          },
+        });
+      }),
+
+    sendRenewalEmail: ({
+      to,
+      name,
+      renewalUrl,
+      expirationDate,
+      planName,
+      daysUntilExpiration,
+      idempotencyKey,
+    }) =>
+      Effect.gen(function* () {
+        if (!resend) {
+          yield* Effect.logWarning(
+            `Skipping renewal email to ${to}: RESEND_API_KEY not configured`,
+          );
+          return;
+        }
+
+        const displayName = name?.trim() || 'Member';
+        const formattedExpiration = expirationDate
+          ? new Date(expirationDate).toLocaleDateString('en-US', {
+              month: 'long',
+              day: 'numeric',
+              year: 'numeric',
+            })
+          : 'your expiration date';
+        const resolvedPlanName = planName || 'Down East Cyclists membership';
+        const isReminder = daysUntilExpiration !== undefined;
+        const subject = isReminder
+          ? `Your Down East Cyclists membership renews in ${daysUntilExpiration} days`
+          : 'Renew your Down East Cyclists membership';
+        const lead = isReminder
+          ? `Your ${resolvedPlanName} expires on ${formattedExpiration}.`
+          : `Your ${resolvedPlanName} has expired or needs renewal.`;
+        const text = [
+          `Hi ${displayName},`,
+          '',
+          lead,
+          'Renew online to keep access to your member benefits and digital membership card.',
+          '',
+          renewalUrl,
+          '',
+          'Down East Cyclists',
+        ].join('\n');
+        const html = `
+          <p>Hi ${escapeHtml(displayName)},</p>
+          <p>${escapeHtml(lead)}</p>
+          <p>Renew online to keep access to your member benefits and digital membership card.</p>
+          <p><a href="${escapeHtml(renewalUrl)}">Renew Membership</a></p>
+          <p>Down East Cyclists</p>
+        `.trim();
+
+        yield* Effect.tryPromise({
+          try: async () => {
+            const payload = renewalTemplateId
+              ? {
+                  from,
+                  to,
+                  subject,
+                  template: {
+                    id: renewalTemplateId,
+                    variables: {
+                      MEMBER_NAME: displayName,
+                      RENEW_URL: renewalUrl,
+                      EXPIRATION_DATE: formattedExpiration,
+                      PLAN_NAME: resolvedPlanName,
+                      DAYS_UNTIL_EXPIRATION: daysUntilExpiration ?? 0,
+                    },
+                  },
+                }
+              : {
+                  from,
+                  to,
+                  subject,
+                  html,
+                  text,
+                };
+
+            const {error} = await resend.emails.send(payload, {idempotencyKey});
+            if (error) {
+              throw error;
+            }
+          },
+          catch: (error) => {
+            const detail = describeResendError(error);
+            console.error('[EmailService] Resend renewal error:', error);
+            return new EmailError({
+              code: 'SEND_RENEWAL_FAILED',
+              message: `Failed to send renewal email to ${to}: ${detail}`,
               cause: error,
             });
           },

--- a/src/lib/effect/membership.service.ts
+++ b/src/lib/effect/membership.service.ts
@@ -8,6 +8,7 @@ import {
   getConfiguredPriceIds,
   getPlanNameForType,
 } from '../membership-plans-config';
+import {isCurrentMembershipStatus} from '../membership-status';
 
 import {MembershipCardService} from './card.service';
 import {DatabaseService} from './database.service';
@@ -339,7 +340,9 @@ const make = Effect.gen(function* () {
         return {
           userId,
           email: user.email,
-          isActive: hasActiveMembershipAccess(membershipData?.status ?? null),
+          isActive:
+            hasActiveMembershipAccess(membershipData?.status ?? null) &&
+            isCurrentMembershipStatus(membershipData?.status, membershipData?.endDate),
           membership: membershipData,
         };
       }),

--- a/src/lib/effect/portal.service.ts
+++ b/src/lib/effect/portal.service.ts
@@ -1,6 +1,7 @@
 import {Context, Effect, Layer, pipe} from 'effect';
 
 import {getPlanNameForType} from '../membership-plans-config';
+import {isCurrentMembershipStatus} from '../membership-status';
 
 import {AuthService} from './auth.service';
 import {DatabaseService} from './database.service';
@@ -87,7 +88,9 @@ const make = Effect.gen(function* () {
             daysRemaining,
           };
 
-          canManageSubscription = !!user.stripeCustomerId;
+          canManageSubscription =
+            !!user.stripeCustomerId &&
+            isCurrentMembershipStatus(membership.status, membership.endDate, now);
         }
 
         return {

--- a/src/lib/effect/renewal-reminders.ts
+++ b/src/lib/effect/renewal-reminders.ts
@@ -1,0 +1,70 @@
+import {Effect} from 'effect';
+
+import {getPlanNameForType} from '../membership-plans-config';
+import {
+  getMembershipDaysUntilExpiration,
+  isRenewalReminderDay,
+  parseMembershipDate,
+} from '../membership-status';
+
+import {DatabaseService} from './database.service';
+import {EmailService} from './email.service';
+
+export interface RenewalReminderResult {
+  sent: number;
+  skipped: number;
+  errors: Array<{email: string; message: string}>;
+}
+
+function getSiteUrl() {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.SITE_URL ||
+    process.env.URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
+}
+
+export const sendScheduledRenewalReminders = Effect.gen(function* () {
+  const db = yield* DatabaseService;
+  const email = yield* EmailService;
+  const now = new Date();
+  const members = yield* db.getExpiringMemberships(90);
+  const renewalUrl = `${getSiteUrl()}/renew`;
+  const initial: RenewalReminderResult = {sent: 0, skipped: 0, errors: []};
+
+  return yield* Effect.reduce(members, initial, (result, member) =>
+    Effect.gen(function* () {
+      if (!member.user || !member.membership) {
+        return {...result, skipped: result.skipped + 1};
+      }
+
+      const daysUntilExpiration = getMembershipDaysUntilExpiration(member.membership.endDate, now);
+      if (!isRenewalReminderDay(daysUntilExpiration)) {
+        return {...result, skipped: result.skipped + 1};
+      }
+
+      const expirationDate = parseMembershipDate(member.membership.endDate)?.toISOString();
+      const sendResult = yield* email
+        .sendRenewalEmail({
+          to: member.user.email,
+          name: member.user.name,
+          renewalUrl,
+          expirationDate,
+          planName: getPlanNameForType(member.membership.planType),
+          daysUntilExpiration,
+          idempotencyKey: `renewal-reminder/${daysUntilExpiration}/${member.user.id}/${now.toISOString().slice(0, 10)}`,
+        })
+        .pipe(Effect.either);
+
+      if (sendResult._tag === 'Left') {
+        return {
+          ...result,
+          errors: [...result.errors, {email: member.user.email, message: sendResult.left.message}],
+        };
+      }
+
+      return {...result, sent: result.sent + 1};
+    }),
+  );
+});

--- a/src/lib/effect/schemas.ts
+++ b/src/lib/effect/schemas.ts
@@ -10,6 +10,10 @@ export const MembershipStatus = S.Literal(
   'incomplete_expired',
   'trialing', // Kept for Stripe compatibility, not used by DEC
   'unpaid',
+  'deleted',
+  'complimentary',
+  'legacy',
+  'expired',
 );
 export type MembershipStatus = S.Schema.Type<typeof MembershipStatus>;
 

--- a/src/lib/effect/stats.service.ts
+++ b/src/lib/effect/stats.service.ts
@@ -1,5 +1,7 @@
 import {Context, Effect, Layer, pipe} from 'effect';
 
+import {isCurrentMembershipStatus} from '../membership-status';
+
 import {DatabaseService} from './database.service';
 import {DatabaseError} from './errors';
 import type {MembershipStats} from './schemas';
@@ -74,14 +76,10 @@ const make = Effect.gen(function* () {
 
       return {
         totalMembers: total,
-        activeMembers: members.filter(
-          (m) => m.membership?.status === 'active' || m.membership?.status === 'trialing',
+        activeMembers: members.filter((m) =>
+          isCurrentMembershipStatus(m.membership?.status, m.membership?.endDate, now),
         ).length,
-        expiredMembers: members.filter((m) => {
-          if (!m.membership) return false;
-          const endDate = toDate(m.membership.endDate);
-          return endDate < now && m.membership.status !== 'canceled';
-        }).length,
+        expiredMembers: members.filter((m) => m.membership?.status === 'expired').length,
         canceledMembers: members.filter((m) => m.membership?.status === 'canceled').length,
         individualCount: members.filter((m) => m.membership?.planType === 'individual').length,
         familyCount: members.filter((m) => m.membership?.planType === 'family').length,
@@ -92,7 +90,9 @@ const make = Effect.gen(function* () {
         }, 0),
         expiringSoonMembers: members.filter((m) => {
           if (!m.membership) return false;
-          if (m.membership.status !== 'active' && m.membership.status !== 'trialing') return false;
+          if (!isCurrentMembershipStatus(m.membership.status, m.membership.endDate, now)) {
+            return false;
+          }
           const endDate = toDate(m.membership.endDate);
           return endDate >= now && endDate <= thirtyDaysFromNow;
         }).length,
@@ -113,7 +113,11 @@ const make = Effect.gen(function* () {
     });
 
   return StatsService.of({
-    getStats: () => pipe(calculateStats(), Effect.catchAll(() => Effect.succeed(defaultStats))),
+    getStats: () =>
+      pipe(
+        calculateStats(),
+        Effect.catchAll(() => Effect.succeed(defaultStats)),
+      ),
 
     // Force recalculation from all memberships
     refreshStats: () =>

--- a/src/lib/membership-access.ts
+++ b/src/lib/membership-access.ts
@@ -91,6 +91,36 @@ export const MEMBERSHIP_ACCESS_RULES: Record<MembershipStatus, MembershipAccessC
     showPaymentWarning: false,
     message: 'Invalid membership status.',
   },
+  deleted: {
+    status: 'deleted',
+    accessLevel: 'none',
+    canAccessMemberContent: false,
+    canAccessMemberDiscounts: false,
+    showPaymentWarning: false,
+    message: 'This membership record has been deleted.',
+  },
+  complimentary: {
+    status: 'complimentary',
+    accessLevel: 'full',
+    canAccessMemberContent: true,
+    canAccessMemberDiscounts: true,
+    showPaymentWarning: false,
+  },
+  legacy: {
+    status: 'legacy',
+    accessLevel: 'full',
+    canAccessMemberContent: true,
+    canAccessMemberDiscounts: true,
+    showPaymentWarning: false,
+  },
+  expired: {
+    status: 'expired',
+    accessLevel: 'none',
+    canAccessMemberContent: false,
+    canAccessMemberDiscounts: false,
+    showPaymentWarning: false,
+    message: 'Your membership has expired. Please renew to restore member access.',
+  },
 };
 
 /**
@@ -105,7 +135,12 @@ export function hasActiveMembershipAccess(status: MembershipStatus | null): bool
 
   // Active members have access
   // Past due members RETAIN access - they already paid for the current period
-  return status === 'active' || status === 'past_due';
+  return (
+    status === 'active' ||
+    status === 'past_due' ||
+    status === 'complimentary' ||
+    status === 'legacy'
+  );
 }
 
 /**

--- a/src/lib/membership-status.ts
+++ b/src/lib/membership-status.ts
@@ -1,0 +1,85 @@
+import type {MembershipStatus} from './effect/schemas';
+
+export type StoredMembershipStatus = Exclude<MembershipStatus, 'expired'>;
+
+const currentStatuses = new Set<string>([
+  'active',
+  'trialing',
+  'past_due',
+  'complimentary',
+  'legacy',
+]);
+
+const inactiveStatuses = new Set<string>([
+  'canceled',
+  'incomplete',
+  'incomplete_expired',
+  'unpaid',
+  'deleted',
+  'expired',
+]);
+
+export function parseMembershipDate(value: unknown): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getMembershipDaysUntilExpiration(endDate: unknown, now: Date = new Date()) {
+  const parsedEndDate = parseMembershipDate(endDate);
+  if (!parsedEndDate) return null;
+
+  return Math.ceil((parsedEndDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+export function isMembershipExpiredByDate(endDate: unknown, now: Date = new Date()): boolean {
+  const parsedEndDate = parseMembershipDate(endDate);
+  return parsedEndDate !== null && parsedEndDate < now;
+}
+
+export function getEffectiveMembershipStatus(
+  status: string | null | undefined,
+  endDate: unknown,
+  now: Date = new Date(),
+): MembershipStatus {
+  const normalizedStatus = status || 'incomplete';
+
+  if (currentStatuses.has(normalizedStatus) && isMembershipExpiredByDate(endDate, now)) {
+    return 'expired';
+  }
+
+  return normalizedStatus as MembershipStatus;
+}
+
+export function isCurrentMembershipStatus(
+  status: string | null | undefined,
+  endDate: unknown,
+  now: Date = new Date(),
+): boolean {
+  if (!status || inactiveStatuses.has(status)) return false;
+  return currentStatuses.has(status) && !isMembershipExpiredByDate(endDate, now);
+}
+
+export function isRenewalReminderDay(
+  daysUntilExpiration: number | null,
+): daysUntilExpiration is 30 | 60 | 90 {
+  return daysUntilExpiration === 30 || daysUntilExpiration === 60 || daysUntilExpiration === 90;
+}
+
+export function toStoredMembershipStatus(status: MembershipStatus): StoredMembershipStatus {
+  switch (status) {
+    case 'active':
+    case 'past_due':
+    case 'canceled':
+    case 'incomplete':
+    case 'incomplete_expired':
+    case 'trialing':
+    case 'unpaid':
+    case 'deleted':
+    case 'complimentary':
+    case 'legacy':
+      return status;
+    case 'expired':
+      throw new Error('Expired is date-based and cannot be stored as a membership status');
+  }
+}


### PR DESCRIPTION
## Summary
- Derive expired membership status from membership end dates so admin and member views show expired members correctly.
- Add the admin renewal email action, Resend template support with inline fallback, and a /renew membership renewal path for expired users.
- Add scheduled 30/60/90 day renewal reminder handling and focused tests for the renewal/status behavior.
- Update env examples and local env organization for the new email and site URL settings.

## Validation
- pnpm fmt:check
- pnpm lint
- pnpm tsc
- pnpm test:run (265 tests passed)

## Notes
- Merged latest origin/master before opening this PR.