### PR TITLE
Add organizer access email automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,8 @@ STRIPE_PRICE_FAMILY=price_xxxxx
 RESEND_API_KEY=re_xxxxx
 EMAIL_FROM="Down East Cyclists <membership@example.com>"
 RESEND_RENEWAL_TEMPLATE_ID=membership-renewal
+RESEND_ORGANIZER_ACCESS_TEMPLATE_ID=organizer-access-granted
+SUPPORT_EMAIL=info@downeastcyclists.com
 
 # ---------------------------------------------------------------------------
 # Contentful

--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ The following environment variables need to be set in Netlify:
 - `STRIPE_PRICE_FAMILY`: Stripe price ID for family membership
 - `ADMIN_EMAIL`: The single administrator account email. Organizer access is granted to member
   accounts from the administrator dashboard.
+- `RESEND_API_KEY`: Resend API key used for transactional email.
+- `EMAIL_FROM`: Verified Resend sender address for member and organizer emails.
+- `RESEND_RENEWAL_TEMPLATE_ID`: Resend template alias or ID for renewal reminders.
+- `RESEND_ORGANIZER_ACCESS_TEMPLATE_ID`: Resend template alias or ID for organizer access
+  notifications. Defaults to `organizer-access-granted`.
+- `SUPPORT_EMAIL`: Reply/support address shown in organizer access emails.
+
+Create or update the Resend templates with:
+
+```shell
+pnpm resend:setup-renewal-template
+pnpm resend:setup-organizer-template
+```
 
 ### Encrypted Credentials
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ const whyJoin = [
 
 export default async function Home() {
   const [video, rides] = await Promise.all([getHeroVideo(), getUpcomingMeetupRides()]);
-  const videoUrl = video.fields.file?.url
+  const videoUrl = video?.fields.file?.url
     ? video.fields.file.url.startsWith('//')
       ? `https:${video.fields.file.url}`
       : video.fields.file.url

--- a/app/trails/b3/page.tsx
+++ b/app/trails/b3/page.tsx
@@ -23,9 +23,9 @@ const trailLinks = [
 
 export default async function B3() {
   const [logo, trailMap, futureMap] = await getB3Assets();
-  const logoUrl = logo.fields.file?.url ? `https:${logo.fields.file.url}` : '';
-  const trailMapUrl = trailMap.fields.file?.url ? `https:${trailMap.fields.file.url}` : '';
-  const futureMapUrl = futureMap.fields.file?.url ? `https:${futureMap.fields.file.url}` : '';
+  const logoUrl = logo?.fields.file?.url ? `https:${logo.fields.file.url}` : '';
+  const trailMapUrl = trailMap?.fields.file?.url ? `https:${trailMap.fields.file.url}` : '';
+  const futureMapUrl = futureMap?.fields.file?.url ? `https:${futureMap.fields.file.url}` : '';
 
   return (
     <main className="dec-page">

--- a/emails/membership-renewal.html
+++ b/emails/membership-renewal.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Renew your Down East Cyclists membership</title>
+  </head>
+  <body style="margin: 0; background: #f4f1ec; font-family: Arial, sans-serif; color: #16130f">
+    <table
+      role="presentation"
+      width="100%"
+      cellspacing="0"
+      cellpadding="0"
+      style="background: #f4f1ec"
+    >
+      <tr>
+        <td align="center" style="padding: 32px 16px">
+          <table
+            role="presentation"
+            width="100%"
+            cellspacing="0"
+            cellpadding="0"
+            style="max-width: 620px; background: #ffffff; border: 1px solid #ddd6cb"
+          >
+            <tr>
+              <td style="background: #16130f; color: #ffffff; padding: 24px 28px">
+                <div
+                  style="
+                    font-size: 12px;
+                    font-weight: 700;
+                    letter-spacing: 1px;
+                    text-transform: uppercase;
+                    color: #f20e02;
+                  "
+                >
+                  Down East Cyclists
+                </div>
+                <h1 style="margin: 8px 0 0; font-size: 28px; line-height: 1.2">
+                  Keep your membership rolling
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 28px">
+                <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5">
+                  Hi {{{MEMBER_NAME}}},
+                </p>
+                <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5">
+                  Your {{{PLAN_NAME}}} expires or has expired on {{{EXPIRATION_DATE}}}.
+                </p>
+                <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.5">
+                  Renew online to keep access to your member benefits, digital membership card, club
+                  updates, and the local rides and trail work your dues help support.
+                </p>
+                <p style="margin: 0 0 28px">
+                  <a
+                    href="{{{RENEW_URL}}}"
+                    style="
+                      display: inline-block;
+                      background: #f20e02;
+                      color: #ffffff;
+                      text-decoration: none;
+                      font-weight: 700;
+                      padding: 13px 18px;
+                    "
+                  >
+                    Renew membership
+                  </a>
+                </p>
+                <h2 style="margin: 0 0 12px; font-size: 18px; line-height: 1.3">
+                  What your membership supports
+                </h2>
+                <ul style="margin: 0 0 24px; padding-left: 22px; font-size: 16px; line-height: 1.5">
+                  <li>Group rides and club communication</li>
+                  <li>Big Branch Bike Park trail stewardship</li>
+                  <li>Safer, stronger cycling in Eastern North Carolina</li>
+                  <li>Your digital membership card and member access</li>
+                </ul>
+                <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5">
+                  Renewal only takes a minute. Open the link below if the button does not work:
+                </p>
+                <p
+                  style="
+                    margin: 0 0 24px;
+                    font-size: 14px;
+                    line-height: 1.5;
+                    word-break: break-word;
+                  "
+                >
+                  <a href="{{{RENEW_URL}}}" style="color: #c20b02; font-weight: 700"
+                    >{{{RENEW_URL}}}</a
+                  >
+                </p>
+                <p style="margin: 24px 0 0; font-size: 16px; line-height: 1.5">
+                  Down East Cyclists
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/emails/membership-renewal.txt
+++ b/emails/membership-renewal.txt
@@ -1,0 +1,17 @@
+Hi {{{MEMBER_NAME}}},
+
+Your {{{PLAN_NAME}}} expires or has expired on {{{EXPIRATION_DATE}}}.
+
+Renew online to keep access to your member benefits, digital membership card, club updates, and the local rides and trail work your dues help support.
+
+Renew here:
+{{{RENEW_URL}}}
+
+What your membership supports:
+
+- Group rides and club communication
+- Big Branch Bike Park trail stewardship
+- Safer, stronger cycling in Eastern North Carolina
+- Your digital membership card and member access
+
+Down East Cyclists

--- a/emails/organizer-access-granted.html
+++ b/emails/organizer-access-granted.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>You now have organizer access to {{{ORG_NAME}}}</title>
+  </head>
+  <body style="margin: 0; background: #f4f1ec; font-family: Arial, sans-serif; color: #16130f">
+    <table
+      role="presentation"
+      width="100%"
+      cellspacing="0"
+      cellpadding="0"
+      style="background: #f4f1ec"
+    >
+      <tr>
+        <td align="center" style="padding: 32px 16px">
+          <table
+            role="presentation"
+            width="100%"
+            cellspacing="0"
+            cellpadding="0"
+            style="max-width: 620px; background: #ffffff; border: 1px solid #ddd6cb"
+          >
+            <tr>
+              <td style="background: #16130f; color: #ffffff; padding: 24px 28px">
+                <div
+                  style="
+                    font-size: 12px;
+                    font-weight: 700;
+                    letter-spacing: 1px;
+                    text-transform: uppercase;
+                    color: #f20e02;
+                  "
+                >
+                  {{{ORG_NAME}}}
+                </div>
+                <h1 style="margin: 8px 0 0; font-size: 28px; line-height: 1.2">
+                  Organizer access granted
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 28px">
+                <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5">
+                  Hi {{{USER_NAME}}},
+                </p>
+                <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5">
+                  You have been granted organizer access to {{{ORG_NAME}}} by {{{GRANTED_BY_NAME}}}.
+                </p>
+                <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.5">
+                  Sign in with {{{USER_EMAIL}}}. If you do not have a password or prefer not to use
+                  one, choose the email sign-in link option on the login page.
+                </p>
+                <p style="margin: 0 0 28px">
+                  <a
+                    href="{{{LOGIN_URL}}}"
+                    style="
+                      display: inline-block;
+                      background: #f20e02;
+                      color: #ffffff;
+                      text-decoration: none;
+                      font-weight: 700;
+                      padding: 13px 18px;
+                    "
+                  >
+                    Sign in
+                  </a>
+                </p>
+                <h2 style="margin: 0 0 12px; font-size: 18px; line-height: 1.3">
+                  Organizer dashboard
+                </h2>
+                <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5">
+                  After signing in, you can open the dashboard here:
+                  <a href="{{{DASHBOARD_URL}}}" style="color: #c20b02; font-weight: 700"
+                    >{{{DASHBOARD_URL}}}</a
+                  >
+                </p>
+                <p style="margin: 0 0 12px; font-size: 16px; line-height: 1.5">
+                  As an organizer, you can:
+                </p>
+                <ul style="margin: 0 0 24px; padding-left: 22px; font-size: 16px; line-height: 1.5">
+                  <li>View membership reports and member details</li>
+                  <li>Export member data</li>
+                  <li>Send password reset emails</li>
+                  <li>Refresh membership statistics</li>
+                  <li>Update trail status information</li>
+                </ul>
+                <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5">
+                  If you believe you received this by mistake or need help accessing the dashboard,
+                  contact
+                  <a href="mailto:{{{SUPPORT_EMAIL}}}" style="color: #c20b02; font-weight: 700"
+                    >{{{SUPPORT_EMAIL}}}</a
+                  >.
+                </p>
+                <p style="margin: 24px 0 0; font-size: 16px; line-height: 1.5">
+                  Down East Cyclists
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/emails/organizer-access-granted.txt
+++ b/emails/organizer-access-granted.txt
@@ -1,0 +1,23 @@
+Hi {{{USER_NAME}}},
+
+You have been granted organizer access to {{{ORG_NAME}}} by {{{GRANTED_BY_NAME}}}.
+
+Sign in with {{{USER_EMAIL}}}:
+{{{LOGIN_URL}}}
+
+After signing in, open the organizer dashboard:
+{{{DASHBOARD_URL}}}
+
+As an organizer, you can:
+
+- View membership reports and member details
+- Export member data
+- Send password reset emails
+- Refresh membership statistics
+- Update trail status information
+
+If you do not have a password or prefer not to use one, choose the email sign-in link option on the login page.
+
+If you believe you received this by mistake or need help accessing the dashboard, contact {{{SUPPORT_EMAIL}}}.
+
+Down East Cyclists

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "format": "oxfmt",
+    "resend:setup-organizer-template": "./scripts/setup-resend-organizer-template.sh",
+    "resend:setup-renewal-template": "./scripts/setup-resend-renewal-template.sh",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/scripts/setup-resend-organizer-template.sh
+++ b/scripts/setup-resend-organizer-template.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+
+set -eu
+
+for env_file in .env .env.local; do
+  if [ -f "$env_file" ]; then
+    set -a
+    . "./$env_file"
+    set +a
+  fi
+done
+
+alias_name="${RESEND_ORGANIZER_ACCESS_TEMPLATE_ID:-organizer-access-granted}"
+template_name="${RESEND_ORGANIZER_ACCESS_TEMPLATE_NAME:-Organizer Access Granted}"
+from_address="${EMAIL_FROM:-Down East Cyclists <noreply@downeastcyclists.com>}"
+support_email="${SUPPORT_EMAIL:-${ADMIN_EMAIL:-info@downeastcyclists.com}}"
+subject="You now have organizer access to {{{ORG_NAME}}}"
+
+html_file="emails/organizer-access-granted.html"
+text_file="emails/organizer-access-granted.txt"
+
+if ! command -v resend >/dev/null 2>&1; then
+  echo "resend CLI is required. Install with: npm install -g resend-cli" >&2
+  exit 1
+fi
+
+if resend templates get "$alias_name" --json >/dev/null 2>&1; then
+  resend templates update "$alias_name" \
+    --name "$template_name" \
+    --alias "$alias_name" \
+    --from "$from_address" \
+    --subject "$subject" \
+    --html-file "$html_file" \
+    --text-file "$text_file" \
+    --var USER_NAME:string:there \
+    --var USER_EMAIL:string \
+    --var ORG_NAME:string:"Down East Cyclists" \
+    --var LOGIN_URL:string \
+    --var DASHBOARD_URL:string \
+    --var GRANTED_BY_NAME:string:"a site administrator" \
+    --var SUPPORT_EMAIL:string:"$support_email" \
+    --json
+else
+  resend templates create \
+    --name "$template_name" \
+    --alias "$alias_name" \
+    --from "$from_address" \
+    --subject "$subject" \
+    --html-file "$html_file" \
+    --text-file "$text_file" \
+    --var USER_NAME:string:there \
+    --var USER_EMAIL:string \
+    --var ORG_NAME:string:"Down East Cyclists" \
+    --var LOGIN_URL:string \
+    --var DASHBOARD_URL:string \
+    --var GRANTED_BY_NAME:string:"a site administrator" \
+    --var SUPPORT_EMAIL:string:"$support_email" \
+    --json
+fi
+
+resend templates publish "$alias_name" --json

--- a/scripts/setup-resend-renewal-template.sh
+++ b/scripts/setup-resend-renewal-template.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+
+set -eu
+
+for env_file in .env .env.local; do
+  if [ -f "$env_file" ]; then
+    set -a
+    . "./$env_file"
+    set +a
+  fi
+done
+
+template_target="${RESEND_RENEWAL_TEMPLATE_ID:-membership-renewal}"
+template_alias="${RESEND_RENEWAL_TEMPLATE_ALIAS:-$template_target}"
+template_name="${RESEND_RENEWAL_TEMPLATE_NAME:-membership-renewal}"
+from_address="${EMAIL_FROM:-Info <info@downeastcyclists.com>}"
+subject="Renew your Down East Cyclists membership"
+
+html_file="emails/membership-renewal.html"
+text_file="emails/membership-renewal.txt"
+
+if ! command -v resend >/dev/null 2>&1; then
+  echo "resend CLI is required. Install with: npm install -g resend-cli" >&2
+  exit 1
+fi
+
+if template_json="$(resend templates get "$template_target" --json 2>/dev/null)"; then
+  template_id="$(printf '%s' "$template_json" | node -e "let input=''; process.stdin.on('data', chunk => input += chunk); process.stdin.on('end', () => console.log(JSON.parse(input).id));")"
+  resend templates update "$template_id" \
+    --name "$template_name" \
+    --alias "$template_alias" \
+    --from "$from_address" \
+    --subject "$subject" \
+    --html-file "$html_file" \
+    --text-file "$text_file" \
+    --var MEMBER_NAME:string:Member \
+    --var PLAN_NAME:string:"Down East Cyclists membership" \
+    --var EXPIRATION_DATE:string:"your membership expiration date" \
+    --var RENEW_URL:string:"https://www.downeastcyclists.com/renew" \
+    --var DAYS_UNTIL_EXPIRATION:number:0 \
+    --json
+else
+  resend templates create \
+    --name "$template_name" \
+    --alias "$template_alias" \
+    --from "$from_address" \
+    --subject "$subject" \
+    --html-file "$html_file" \
+    --text-file "$text_file" \
+    --var MEMBER_NAME:string:Member \
+    --var PLAN_NAME:string:"Down East Cyclists membership" \
+    --var EXPIRATION_DATE:string:"your membership expiration date" \
+    --var RENEW_URL:string:"https://www.downeastcyclists.com/renew" \
+    --var DAYS_UNTIL_EXPIRATION:number:0 \
+    --json
+fi
+
+resend templates publish "$template_alias" --json

--- a/src/__tests__/layers/test-layers.ts
+++ b/src/__tests__/layers/test-layers.ts
@@ -139,6 +139,7 @@ export const createTestEmailService = (
 ): EmailServiceType => ({
   sendWelcomeEmail: vi.fn(() => Effect.void),
   sendRenewalEmail: vi.fn(() => Effect.void),
+  sendOrganizerAccessGrantedEmail: vi.fn(() => Effect.void),
   ...overrides,
 });
 

--- a/src/__tests__/services/admin-access.service.test.ts
+++ b/src/__tests__/services/admin-access.service.test.ts
@@ -33,6 +33,7 @@ const stats = {
 function makeLayer(
   authService: ReturnType<typeof createTestAuthService>,
   databaseService: ReturnType<typeof createTestDatabaseService>,
+  emailService = createTestEmailService(),
 ) {
   const statsService = StatsService.of({
     getStats: () => Effect.succeed(stats),
@@ -47,7 +48,7 @@ function makeLayer(
     TestStripeLayer(createTestStripeService()),
     Layer.succeed(MembershipCardService, createTestCardService()),
     Layer.succeed(StatsService, statsService),
-    TestEmailLayer(createTestEmailService()),
+    TestEmailLayer(emailService),
   );
 }
 
@@ -55,11 +56,12 @@ function runWithAdminService<A, E>(
   program: Effect.Effect<A, E, AdminService>,
   authService: ReturnType<typeof createTestAuthService>,
   databaseService: ReturnType<typeof createTestDatabaseService>,
+  emailService = createTestEmailService(),
 ) {
   return Effect.runPromise(
     program.pipe(
       Effect.provide(AdminServiceLive),
-      Effect.provide(makeLayer(authService, databaseService)),
+      Effect.provide(makeLayer(authService, databaseService, emailService)),
     ),
   );
 }
@@ -161,6 +163,7 @@ describe('AdminService access control', () => {
   it('lets the administrator grant organizer access and records the change', async () => {
     const updateUser = vi.fn(() => Effect.void);
     const logAuditEntry = vi.fn(() => Effect.void);
+    const emailService = createTestEmailService();
     const authService = createTestAuthService({
       verifyAdminClaim: () =>
         Effect.succeed({uid: 'admin_uid', email: 'admin@example.com', isAdmin: true}),
@@ -178,6 +181,7 @@ describe('AdminService access control', () => {
       ),
       authService,
       databaseService,
+      emailService,
     );
 
     expect(updateUser).toHaveBeenCalledWith('member_uid', {isOrganizer: true});
@@ -191,6 +195,38 @@ describe('AdminService access control', () => {
         newValue: true,
       }),
     );
+    expect(emailService.sendOrganizerAccessGrantedEmail).toHaveBeenCalledWith({
+      to: 'test@example.com',
+      name: 'Test User',
+      loginUrl: 'http://localhost:3000/login',
+      dashboardUrl: 'http://localhost:3000/dashboard',
+      grantedByName: 'admin@example.com',
+      supportEmail: 'admin@example.com',
+      idempotencyKey: 'organizer-access-granted/member_uid',
+    });
+  });
+
+  it('does not resend organizer access email when the member is already an organizer', async () => {
+    const emailService = createTestEmailService();
+    const authService = createTestAuthService({
+      verifyAdminClaim: () =>
+        Effect.succeed({uid: 'admin_uid', email: 'admin@example.com', isAdmin: true}),
+    });
+    const databaseService = createTestDatabaseService({
+      getUser: () => Effect.succeed(createMockUserDocument({id: 'member_uid', isOrganizer: true})),
+      getActiveMembership: () => Effect.succeed(createMockMembershipDocument()),
+    });
+
+    await runWithAdminService(
+      Effect.flatMap(AdminService, (service) =>
+        service.setOrganizerRole('session', 'member_uid', true),
+      ),
+      authService,
+      databaseService,
+      emailService,
+    );
+
+    expect(emailService.sendOrganizerAccessGrantedEmail).not.toHaveBeenCalled();
   });
 
   it('rejects organizer grants for members without a current membership', async () => {

--- a/src/contentful/contentfulClient.ts
+++ b/src/contentful/contentfulClient.ts
@@ -1,14 +1,32 @@
-import {createClient} from 'contentful';
+import {createClient, EntrySkeletonType} from 'contentful';
 import {cache} from 'react';
+
+const hasContentfulConfig = Boolean(
+  process.env.CONTENTFUL_SPACE_ID && process.env.CONTENTFUL_ACCESS_TOKEN,
+);
 
 // Create Contentful client
 export const client = createClient({
-  space: process.env.CONTENTFUL_SPACE_ID || '',
-  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN || '',
+  space: process.env.CONTENTFUL_SPACE_ID || 'missing-space',
+  accessToken: process.env.CONTENTFUL_ACCESS_TOKEN || 'missing-token',
 });
 
 // Create cached version of the client's getEntries method
-export const getEntriesCached = cache(client.getEntries.bind(client));
+export const getEntriesCached = cache(
+  <T extends EntrySkeletonType>(query: Parameters<typeof client.getEntries<T>>[0]) => {
+    if (!hasContentfulConfig) {
+      return Promise.resolve({items: [], total: 0});
+    }
+
+    return client.getEntries<T>(query);
+  },
+);
 
 // Create cached version of the client's getAsset method
-export const getAssetCached = cache(client.getAsset.bind(client));
+export const getAssetCached = cache((assetId: string) => {
+  if (!hasContentfulConfig) {
+    return Promise.resolve(null);
+  }
+
+  return client.getAsset(assetId);
+});

--- a/src/lib/effect/admin.service.ts
+++ b/src/lib/effect/admin.service.ts
@@ -239,6 +239,10 @@ function getSiteUrl() {
   ).replace(/\/$/, '');
 }
 
+function getSupportEmail() {
+  return process.env.SUPPORT_EMAIL || process.env.ADMIN_EMAIL || 'info@downeastcyclists.com';
+}
+
 function getSubscriptionPeriodDates(subscription: Stripe.Subscription): {
   periodStart?: number;
   periodEnd?: number;
@@ -642,6 +646,7 @@ const make = Effect.gen(function* () {
           }
         }
 
+        const wasOrganizer = member.isOrganizer === true;
         yield* db.updateUser(targetUid, {isOrganizer});
         yield* db.logAuditEntry(targetUid, 'ADMIN_ROLE_CHANGE', {
           performedBy: admin.uid,
@@ -654,6 +659,26 @@ const make = Effect.gen(function* () {
         yield* Effect.log(
           `Organizer role ${isOrganizer ? 'granted to' : 'revoked from'} ${targetUid} by ${admin.uid}`,
         );
+
+        if (isOrganizer && !wasOrganizer) {
+          yield* emailService
+            .sendOrganizerAccessGrantedEmail({
+              to: member.email,
+              name: member.name,
+              loginUrl: `${getSiteUrl()}/login`,
+              dashboardUrl: `${getSiteUrl()}/dashboard`,
+              grantedByName: admin.email,
+              supportEmail: getSupportEmail(),
+              idempotencyKey: `organizer-access-granted/${targetUid}`,
+            })
+            .pipe(
+              Effect.catchTag('EmailError', (error) =>
+                Effect.logWarning(
+                  `Organizer access email not sent to ${member.email}: ${JSON.stringify(error)}`,
+                ),
+              ),
+            );
+        }
       }),
 
     // Search members

--- a/src/lib/effect/email.service.ts
+++ b/src/lib/effect/email.service.ts
@@ -19,6 +19,16 @@ export interface EmailService {
     daysUntilExpiration?: 30 | 60 | 90;
     idempotencyKey: string;
   }) => Effect.Effect<void, EmailError>;
+
+  readonly sendOrganizerAccessGrantedEmail: (params: {
+    to: string;
+    name: string | undefined;
+    loginUrl: string;
+    dashboardUrl: string;
+    grantedByName: string | undefined;
+    supportEmail: string;
+    idempotencyKey: string;
+  }) => Effect.Effect<void, EmailError>;
 }
 
 export const EmailService = Context.GenericTag<EmailService>('EmailService');
@@ -32,6 +42,8 @@ const make = Effect.gen(function* () {
   const resend = apiKey ? new Resend(apiKey) : null;
   const from = process.env.EMAIL_FROM ?? 'Down East Cyclists <noreply@downeastcyclists.com>';
   const renewalTemplateId = process.env.RESEND_RENEWAL_TEMPLATE_ID;
+  const organizerTemplateId =
+    process.env.RESEND_ORGANIZER_ACCESS_TEMPLATE_ID ?? 'organizer-access-granted';
 
   const describeResendError = (error: unknown) =>
     error instanceof Error
@@ -188,6 +200,130 @@ const make = Effect.gen(function* () {
             });
           },
         });
+      }),
+
+    sendOrganizerAccessGrantedEmail: ({
+      to,
+      name,
+      loginUrl,
+      dashboardUrl,
+      grantedByName,
+      supportEmail,
+      idempotencyKey,
+    }) =>
+      Effect.gen(function* () {
+        if (!resend) {
+          yield* Effect.logWarning(
+            `Skipping organizer access email to ${to}: RESEND_API_KEY not configured`,
+          );
+          return;
+        }
+
+        const displayName = name?.trim() || 'there';
+        const actorName = grantedByName?.trim() || 'a site administrator';
+        const subject = 'You now have organizer access to Down East Cyclists';
+        const text = [
+          `Hi ${displayName},`,
+          '',
+          `You have been granted organizer access to Down East Cyclists by ${actorName}.`,
+          '',
+          'Sign in with your member account:',
+          loginUrl,
+          '',
+          'After signing in, open the organizer dashboard:',
+          dashboardUrl,
+          '',
+          'As an organizer, you can view membership reports, export member data, send password reset emails, refresh membership stats, and update trail status information.',
+          '',
+          `Use ${to} when signing in. If you do not have a password or prefer not to use one, choose the email sign-in link option on the login page.`,
+          '',
+          `If you believe you received this by mistake or need help accessing the dashboard, contact ${supportEmail}.`,
+          '',
+          'Down East Cyclists',
+        ].join('\n');
+
+        const html = `
+          <p>Hi ${escapeHtml(displayName)},</p>
+          <p>You have been granted organizer access to Down East Cyclists by ${escapeHtml(actorName)}.</p>
+          <p><a href="${escapeHtml(loginUrl)}">Sign in to your account</a></p>
+          <p>After signing in, open the organizer dashboard:</p>
+          <p><a href="${escapeHtml(dashboardUrl)}">Open organizer dashboard</a></p>
+          <p>As an organizer, you can view membership reports, export member data, send password reset emails, refresh membership stats, and update trail status information.</p>
+          <p>Use ${escapeHtml(to)} when signing in. If you do not have a password or prefer not to use one, choose the email sign-in link option on the login page.</p>
+          <p>If you believe you received this by mistake or need help accessing the dashboard, contact ${escapeHtml(supportEmail)}.</p>
+          <p>Down East Cyclists</p>
+        `.trim();
+
+        yield* Effect.tryPromise({
+          try: async () => {
+            const {error} = await resend.emails.send(
+              {
+                from,
+                to,
+                subject,
+                template: {
+                  id: organizerTemplateId,
+                  variables: {
+                    USER_NAME: displayName,
+                    USER_EMAIL: to,
+                    ORG_NAME: 'Down East Cyclists',
+                    LOGIN_URL: loginUrl,
+                    DASHBOARD_URL: dashboardUrl,
+                    GRANTED_BY_NAME: actorName,
+                    SUPPORT_EMAIL: supportEmail,
+                  },
+                },
+              },
+              {idempotencyKey},
+            );
+            if (error) {
+              throw error;
+            }
+          },
+          catch: (error) => {
+            const detail = describeResendError(error);
+            console.error('[EmailService] Resend organizer access error:', error);
+            return new EmailError({
+              code: 'SEND_ORGANIZER_ACCESS_FAILED',
+              message: `Failed to send organizer access email to ${to}: ${detail}`,
+              cause: error,
+            });
+          },
+        }).pipe(
+          Effect.catchTag('EmailError', (templateError) =>
+            Effect.gen(function* () {
+              yield* Effect.logWarning(
+                `Template organizer access email failed for ${to}; trying inline fallback: ${templateError.message}`,
+              );
+              yield* Effect.tryPromise({
+                try: async () => {
+                  const {error} = await resend.emails.send(
+                    {
+                      from,
+                      to,
+                      subject,
+                      html,
+                      text,
+                    },
+                    {idempotencyKey: `${idempotencyKey}/inline`},
+                  );
+                  if (error) {
+                    throw error;
+                  }
+                },
+                catch: (error) => {
+                  const detail = describeResendError(error);
+                  console.error('[EmailService] Resend organizer access fallback error:', error);
+                  return new EmailError({
+                    code: 'SEND_ORGANIZER_ACCESS_FAILED',
+                    message: `Failed to send organizer access email to ${to}: ${detail}`,
+                    cause: error,
+                  });
+                },
+              });
+            }),
+          ),
+        );
       }),
   });
 });

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -2,15 +2,18 @@
 import {initializeApp} from 'firebase/app';
 import {getAuth, signInWithEmailAndPassword, signOut, User} from 'firebase/auth';
 
+const firebaseApiKey =
+  process.env.NEXT_PUBLIC_FIREBASE_API_KEY || 'AIzaSyDUMMYDUMMYDUMMYDUMMYDUMMYDUMMY';
+
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.GOOGLE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  apiKey: firebaseApiKey,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || 'missing.firebaseapp.com',
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || process.env.GOOGLE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || '',
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || '',
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || '1:000000000000:web:0000000000000000000000',
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID || '',
 };
 


### PR DESCRIPTION
## Summary

- Sends an automatic Resend notification when an admin grants organizer access to a member for the first time.
- Adds the organizer access email template and setup script, plus a refreshed membership renewal template and setup script.
- Documents Resend environment variables and template setup commands.
- Adds small build-time guards for missing Contentful/Firebase env so production builds still complete in local worktrees.

## Resend template status

- `organizer-access-granted` was created and published.
- `membership-renewal` was refreshed, published, and its alias was restored to `membership-renewal`.

## Validation

- `pnpm tsgo`
- `pnpm lint`
- `pnpm test:run`
- `pnpm fmt:check`
- `pnpm build`