### PR TITLE
Fix frictionless renewal links

### DIFF
--- a/app/renew/complete/page.tsx
+++ b/app/renew/complete/page.tsx
@@ -1,0 +1,53 @@
+import {Alert, Box, Button, Paper, Typography} from '@mui/material';
+import Link from 'next/link';
+import {redirect} from 'next/navigation';
+
+export const metadata = {
+  title: 'Renewal Received - Down East Cyclists',
+  description: 'Your Down East Cyclists membership renewal payment was received',
+};
+
+interface RenewalCompletePageProps {
+  searchParams: Promise<{session_id?: string; userId?: string}>;
+}
+
+export default async function RenewalCompletePage({searchParams}: RenewalCompletePageProps) {
+  const params = await searchParams;
+
+  if (!params.session_id) {
+    redirect(params.userId ? `/renew?userId=${encodeURIComponent(params.userId)}` : '/renew');
+  }
+
+  return (
+    <main className="dec-page">
+      <section className="dec-container py-16 md:py-20">
+        <Paper className="dec-card" elevation={0} sx={{mx: 'auto', maxWidth: 720, p: 4}}>
+          <Typography
+            variant="overline"
+            sx={{color: '#F20E02', fontWeight: 800, letterSpacing: '.1em'}}
+          >
+            MEMBERSHIP
+          </Typography>
+          <Typography variant="h1" sx={{fontSize: {xs: 48, md: 72}, mb: 2}}>
+            Renewal received
+          </Typography>
+          <Alert severity="success" sx={{mb: 3}}>
+            Your payment was submitted. Membership updates usually appear after Stripe finishes
+            processing the checkout.
+          </Alert>
+          <Typography color="text.secondary" sx={{mb: 4}}>
+            You can sign in to view your digital membership card and manage your account.
+          </Typography>
+          <Box sx={{display: 'flex', flexWrap: 'wrap', gap: 2}}>
+            <Button component={Link} href="/login" variant="contained">
+              Sign in
+            </Button>
+            <Button component={Link} href="/" variant="outlined">
+              Return home
+            </Button>
+          </Box>
+        </Paper>
+      </section>
+    </main>
+  );
+}

--- a/app/renew/page.tsx
+++ b/app/renew/page.tsx
@@ -1,7 +1,8 @@
 import {Alert} from '@mui/material';
 import {redirect} from 'next/navigation';
 
-import {getMemberDashboard} from '@/src/actions/portal';
+import {verifySession} from '@/src/actions/auth';
+import {getRenewalDashboard} from '@/src/actions/portal';
 import {RenewMembershipClient} from '@/src/components/membership/RenewMembershipClient';
 
 export const metadata = {
@@ -10,14 +11,17 @@ export const metadata = {
 };
 
 interface RenewPageProps {
-  searchParams: Promise<{canceled?: string}>;
+  searchParams: Promise<{canceled?: string; userId?: string}>;
 }
 
 export default async function RenewPage({searchParams}: RenewPageProps) {
   const params = await searchParams;
-  const dashboardData = await getMemberDashboard();
+  const isDirectRenewal = Boolean(params.userId);
+  const session = params.userId ? null : await verifySession();
+  const renewalUserId = params.userId || session?.userId;
+  const dashboardData = renewalUserId ? await getRenewalDashboard(renewalUserId) : null;
 
-  if ('error' in dashboardData) {
+  if (dashboardData && 'error' in dashboardData) {
     return (
       <main className="dec-page">
         <section className="dec-container py-16">
@@ -28,6 +32,8 @@ export default async function RenewPage({searchParams}: RenewPageProps) {
   }
 
   if (
+    dashboardData &&
+    !isDirectRenewal &&
     dashboardData.membership &&
     dashboardData.membership.status !== 'expired' &&
     dashboardData.membership.daysRemaining > 0
@@ -47,11 +53,12 @@ export default async function RenewPage({searchParams}: RenewPageProps) {
 
       <section className="dec-container pb-20">
         <RenewMembershipClient
-          userId={dashboardData.user.id}
-          email={dashboardData.user.email}
-          name={dashboardData.user.name}
+          userId={dashboardData?.user.id}
+          email={dashboardData?.user.email}
+          name={dashboardData?.user.name ?? null}
           canceled={params.canceled === 'true'}
-          expiredOn={dashboardData.membership?.endDate}
+          expiredOn={dashboardData?.membership?.endDate}
+          publicRenewal={isDirectRenewal || !session?.authenticated}
         />
       </section>
     </main>

--- a/src/__tests__/integration/admin-member-management.test.ts
+++ b/src/__tests__/integration/admin-member-management.test.ts
@@ -797,7 +797,7 @@ describe('Admin Member Management Integration', () => {
         expect.objectContaining({
           to: 'expired@example.com',
           name: 'Expired Member',
-          renewalUrl: expect.stringContaining('/renew'),
+          renewalUrl: expect.stringContaining('/renew?userId=user_renew'),
         }),
       );
       expect(databaseService.logAuditEntry).toHaveBeenCalledWith(

--- a/src/__tests__/services/renewal-reminders.test.ts
+++ b/src/__tests__/services/renewal-reminders.test.ts
@@ -80,6 +80,7 @@ describe('sendScheduledRenewalReminders', () => {
       expect.objectContaining({
         to: 'thirty@example.com',
         daysUntilExpiration: 30,
+        renewalUrl: expect.stringContaining('/renew?userId=user_30'),
       }),
     );
   });

--- a/src/actions/portal.ts
+++ b/src/actions/portal.ts
@@ -8,6 +8,29 @@ import {LiveLayer} from '@/src/lib/effect/layers';
 import {PortalService} from '@/src/lib/effect/portal.service';
 import type {MemberDashboardResponse} from '@/src/lib/effect/schemas';
 
+function dashboardErrorFromExit(exit: Exit.Exit<MemberDashboardResponse, unknown>) {
+  if (!Exit.isFailure(exit)) {
+    return null;
+  }
+
+  const cause = exit.cause;
+  const failure = cause._tag === 'Fail' ? cause.error : null;
+
+  if (failure && typeof failure === 'object' && '_tag' in failure) {
+    if (failure._tag === 'SessionError') {
+      redirect('/login');
+    }
+    if (failure._tag === 'NotFoundError' && 'resource' in failure) {
+      return {error: `${failure.resource} not found`};
+    }
+    if (failure._tag === 'DatabaseError' && 'message' in failure) {
+      return {error: failure.message as string};
+    }
+  }
+
+  return {error: 'An unexpected error occurred'};
+}
+
 // Get member dashboard data - Effect.gen for complex flow
 export async function getMemberDashboard(): Promise<MemberDashboardResponse | {error: string}> {
   const cookieStore = await cookies();
@@ -28,27 +51,39 @@ export async function getMemberDashboard(): Promise<MemberDashboardResponse | {e
   });
 
   const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(LiveLayer)));
+  const error = dashboardErrorFromExit(exit);
 
-  if (Exit.isFailure(exit)) {
-    const cause = exit.cause;
-    // Check the error type from the cause
-    const failure = cause._tag === 'Fail' ? cause.error : null;
-
-    if (failure && typeof failure === 'object' && '_tag' in failure) {
-      if (failure._tag === 'SessionError') {
-        redirect('/login');
-      }
-      if (failure._tag === 'NotFoundError' && 'resource' in failure) {
-        return {error: `${failure.resource} not found`};
-      }
-      if (failure._tag === 'DatabaseError' && 'message' in failure) {
-        return {error: failure.message as string};
-      }
-    }
-    return {error: 'An unexpected error occurred'};
+  if (error) {
+    return error;
   }
 
-  return exit.value;
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+
+  return {error: 'An unexpected error occurred'};
+}
+
+export async function getRenewalDashboard(
+  userId: string,
+): Promise<MemberDashboardResponse | {error: string}> {
+  const program = Effect.gen(function* () {
+    const portal = yield* PortalService;
+    return yield* portal.getMemberDashboard(userId);
+  });
+
+  const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(LiveLayer)));
+  const error = dashboardErrorFromExit(exit);
+
+  if (error) {
+    return error;
+  }
+
+  if (Exit.isSuccess(exit)) {
+    return exit.value;
+  }
+
+  return {error: 'An unexpected error occurred'};
 }
 
 // Redirect to Stripe Customer Portal

--- a/src/components/membership/RenewMembershipClient.tsx
+++ b/src/components/membership/RenewMembershipClient.tsx
@@ -9,6 +9,7 @@ import {
   FormControlLabel,
   Grid,
   Paper,
+  TextField,
   Typography,
 } from '@mui/material';
 import {useMutation, useQuery} from '@tanstack/react-query';
@@ -17,11 +18,12 @@ import {useEffect, useState} from 'react';
 import {PlanCard, type MembershipPlan} from './PlanCard';
 
 interface RenewMembershipClientProps {
-  userId: string;
-  email: string;
+  userId?: string;
+  email?: string;
   name: string | null;
   canceled: boolean;
   expiredOn?: string;
+  publicRenewal: boolean;
 }
 
 interface CheckoutResponse {
@@ -34,12 +36,14 @@ export function RenewMembershipClient({
   name,
   canceled,
   expiredOn,
+  publicRenewal,
 }: RenewMembershipClientProps) {
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
   const [selectedPriceId, setSelectedPriceId] = useState<string | null>(null);
   const [selectedPlanPrice, setSelectedPlanPrice] = useState(0);
   const [coverFees, setCoverFees] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [checkoutEmail, setCheckoutEmail] = useState('');
 
   const plansQuery = useQuery<MembershipPlan[]>({
     queryKey: ['membership-plans'],
@@ -58,16 +62,21 @@ export function RenewMembershipClient({
         throw new Error('Please select a membership plan');
       }
 
+      const emailForCheckout = (email || checkoutEmail).trim();
       const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin;
+      const renewalParams = new URLSearchParams(userId ? {userId} : {});
+      const renewalQuery = renewalParams.toString();
       const response = await fetch('/api/checkout', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
           priceId: selectedPriceId,
           userId,
-          email,
-          successUrl: `${siteUrl}/member?session_id={CHECKOUT_SESSION_ID}`,
-          cancelUrl: `${siteUrl}/renew?canceled=true`,
+          email: emailForCheckout,
+          successUrl: publicRenewal
+            ? `${siteUrl}/renew/complete?${userId ? `userId=${encodeURIComponent(userId)}&` : ''}session_id={CHECKOUT_SESSION_ID}`
+            : `${siteUrl}/member?session_id={CHECKOUT_SESSION_ID}`,
+          cancelUrl: `${siteUrl}/renew?${renewalQuery ? `${renewalQuery}&` : ''}canceled=true`,
           coverFees,
           planPrice: selectedPlanPrice,
         }),
@@ -100,8 +109,15 @@ export function RenewMembershipClient({
 
   const processingFee = selectedPlanPrice > 0 ? selectedPlanPrice * 0.027 + 0.05 : 0;
   const errorMessage = validationError || checkoutMutation.error?.message || null;
+  const needsEmail = !email;
+  const emailForCheckout = (email || checkoutEmail).trim();
 
   const handleSubmit = () => {
+    if (needsEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailForCheckout)) {
+      setValidationError('Please enter a valid email address');
+      return;
+    }
+
     if (!selectedPriceId) {
       setValidationError('Please select a membership plan');
       return;
@@ -159,8 +175,22 @@ export function RenewMembershipClient({
         <Box sx={{display: 'grid', gap: 1.5, my: 3}}>
           <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
             <Typography color="text.secondary">Account</Typography>
-            <Typography fontWeight={700}>{name || email}</Typography>
+            <Typography fontWeight={700}>{name || email || 'Enter email below'}</Typography>
           </Box>
+          {needsEmail && (
+            <TextField
+              label="Email"
+              type="email"
+              value={checkoutEmail}
+              onChange={(event) => {
+                setCheckoutEmail(event.target.value);
+                setValidationError(null);
+              }}
+              disabled={checkoutMutation.isPending}
+              fullWidth
+              required
+            />
+          )}
           {expiredOn && (
             <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2}}>
               <Typography color="text.secondary">Expired</Typography>

--- a/src/lib/effect/admin.service.ts
+++ b/src/lib/effect/admin.service.ts
@@ -14,6 +14,8 @@ import {
   parseMembershipDate,
 } from '@/src/lib/membership-status';
 import {isPrimaryAdminEmail} from '@/src/lib/primary-admin';
+import {buildRenewalUrl} from '@/src/lib/renewal-link';
+import {getSiteUrl} from '@/src/lib/site-url';
 import type {
   AuditEntry,
   BulkImportResult,
@@ -228,15 +230,6 @@ function describeStripeError(error: StripeError): string {
         : undefined;
 
   return causeMessage ? `${error.message}: ${causeMessage}` : error.message;
-}
-
-function getSiteUrl() {
-  return (
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    process.env.SITE_URL ||
-    process.env.URL ||
-    'http://localhost:3000'
-  ).replace(/\/$/, '');
 }
 
 function getSupportEmail() {
@@ -1507,7 +1500,7 @@ const make = Effect.gen(function* () {
         }
 
         const membership = yield* db.getActiveMembership(userId);
-        const renewalUrl = `${getSiteUrl()}/renew`;
+        const renewalUrl = buildRenewalUrl(user.id);
         const endDate = membership ? parseMembershipDate(membership.endDate) : null;
         const daysUntilExpiration = membership
           ? getMembershipDaysUntilExpiration(membership.endDate)

--- a/src/lib/effect/renewal-reminders.ts
+++ b/src/lib/effect/renewal-reminders.ts
@@ -6,6 +6,7 @@ import {
   isRenewalReminderDay,
   parseMembershipDate,
 } from '../membership-status';
+import {buildRenewalUrl} from '../renewal-link';
 
 import {DatabaseService} from './database.service';
 import {EmailService} from './email.service';
@@ -16,21 +17,11 @@ export interface RenewalReminderResult {
   errors: Array<{email: string; message: string}>;
 }
 
-function getSiteUrl() {
-  return (
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    process.env.SITE_URL ||
-    process.env.URL ||
-    'http://localhost:3000'
-  ).replace(/\/$/, '');
-}
-
 export const sendScheduledRenewalReminders = Effect.gen(function* () {
   const db = yield* DatabaseService;
   const email = yield* EmailService;
   const now = new Date();
   const members = yield* db.getExpiringMemberships(90);
-  const renewalUrl = `${getSiteUrl()}/renew`;
   const initial: RenewalReminderResult = {sent: 0, skipped: 0, errors: []};
 
   return yield* Effect.reduce(members, initial, (result, member) =>
@@ -49,7 +40,7 @@ export const sendScheduledRenewalReminders = Effect.gen(function* () {
         .sendRenewalEmail({
           to: member.user.email,
           name: member.user.name,
-          renewalUrl,
+          renewalUrl: buildRenewalUrl(member.user.id),
           expirationDate,
           planName: getPlanNameForType(member.membership.planType),
           daysUntilExpiration,

--- a/src/lib/renewal-link.ts
+++ b/src/lib/renewal-link.ts
@@ -1,0 +1,7 @@
+import {getSiteUrl} from './site-url';
+
+export function buildRenewalUrl(userId: string) {
+  const url = new URL('/renew', getSiteUrl());
+  url.searchParams.set('userId', userId);
+  return url.toString();
+}

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,8 @@
+export function getSiteUrl() {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.SITE_URL ||
+    process.env.URL ||
+    'http://localhost:3000'
+  ).replace(/\/$/, '');
+}


### PR DESCRIPTION
## Summary

- Add member-specific renewal URLs to admin-triggered and scheduled renewal emails.
- Let `/renew?userId=...` load the intended member without requiring a login session.
- Keep old/plain `/renew` links usable by showing a public email-based renewal form instead of blocking unauthenticated members.
- Add a public `/renew/complete` confirmation page so Stripe success redirects do not land behind the member login gate.

## Root Cause

Renewal emails linked to plain `/renew`, but that page only loaded the current logged-in member dashboard. If the recipient was not logged in, or was not logged into the matching account, the renewal page could surface `user not found` or otherwise block checkout. Scheduled reminders also targeted active-but-expiring members, but `/renew` redirected active members away from checkout.

## Validation

- `pnpm tsgo`
- `pnpm lint`
- `pnpm test:run`
- `pnpm fmt:check`
- `pnpm build`
