### PR TITLE
Add trail maintenance reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,27 @@ RESEND_ORGANIZER_ACCESS_TEMPLATE_ID=organizer-access-granted
 SUPPORT_EMAIL=info@downeastcyclists.com
 
 # ---------------------------------------------------------------------------
+# Trail maintenance reports
+# ---------------------------------------------------------------------------
+ONSLOW_PARKS_EMAIL=parks@example.gov
+
+# Cloudflare Turnstile
+# The site key is public and must use NEXT_PUBLIC_ so the browser can render the widget.
+# For local testing, Cloudflare provides always-pass dummy keys:
+# NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+# CLOUDFLARE_TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=0x4AAAAAA-your-site-key
+CLOUDFLARE_TURNSTILE_SECRET_KEY=0x4AAAAAA-your-secret-key
+CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES=localhost,downeastcyclists.com
+TRAIL_MAINTENANCE_SKIP_TURNSTILE=false
+
+# Cloudflare R2 private bucket for submitted trail issue photos.
+R2_ACCOUNT_ID=your-cloudflare-account-id
+R2_ACCESS_KEY_ID=your-r2-access-key-id
+R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+R2_BUCKET_NAME=downeastcyclists-trail-issue-photos
+
+# ---------------------------------------------------------------------------
 # Contentful
 # ---------------------------------------------------------------------------
 CONTENTFUL_SPACE_ID=your-contentful-space-id

--- a/app/api/admin/trail-maintenance/reports/[reportId]/county-email/route.ts
+++ b/app/api/admin/trail-maintenance/reports/[reportId]/county-email/route.ts
@@ -1,0 +1,91 @@
+import {Effect} from 'effect';
+import {NextRequest} from 'next/server';
+
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+import {DatabaseError, NotFoundError} from '@/src/lib/effect/errors';
+import {
+  getTrailMaintenanceReportDetail,
+  markCountyEmailGenerated,
+} from '@/src/lib/trail-maintenance/repository';
+
+interface RouteContext {
+  readonly params: Promise<{readonly reportId: string}>;
+}
+
+function googleMapsUrl(latitude: number, longitude: number): string {
+  return `https://www.google.com/maps?q=${latitude},${longitude}`;
+}
+
+export async function POST(_request: NextRequest, context: RouteContext) {
+  const {reportId} = await context.params;
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        const session = yield* admin.authorize(sessionCookie, 'trail-maintenance:manage');
+        const report = yield* Effect.tryPromise({
+          try: () => getTrailMaintenanceReportDetail(reportId),
+          catch: (error) =>
+            new DatabaseError({
+              code: 'TRAIL_MAINTENANCE_COUNTY_DRAFT_LOAD_FAILED',
+              message: 'Failed to load trail maintenance report',
+              cause: error,
+            }),
+        });
+        if (!report) {
+          return yield* Effect.fail(new NotFoundError({resource: 'Trail report', id: reportId}));
+        }
+
+        yield* Effect.tryPromise({
+          try: () =>
+            markCountyEmailGenerated({
+              reportId,
+              actor: {uid: session.uid, email: session.email},
+            }),
+          catch: (error) =>
+            new DatabaseError({
+              code: 'TRAIL_MAINTENANCE_COUNTY_DRAFT_LOG_FAILED',
+              message: 'Failed to log county email draft',
+              cause: error,
+            }),
+        });
+
+        const locationLine =
+          report.latitude !== null && report.longitude !== null
+            ? `${report.latitude.toFixed(6)}, ${report.longitude.toFixed(6)} (${googleMapsUrl(
+                report.latitude,
+                report.longitude,
+              )})`
+            : report.locationNotes || 'Location notes unavailable';
+
+        const subject = `Big Branch Bike Park maintenance issue ${report.publicId}`;
+        const body = [
+          'Onslow County Parks and Recreation team,',
+          '',
+          'Down East Cyclists received a trail maintenance report that appears to need county support.',
+          '',
+          `Report: ${report.publicId}`,
+          `Issue: ${report.issueTypeLabel}`,
+          `Trail: ${report.trailSystemName}${report.trailSegmentName ? ` - ${report.trailSegmentName}` : ''}`,
+          `Observed: ${new Date(report.observedAt).toLocaleString()}`,
+          `Location: ${locationLine}`,
+          report.description ? `Reporter notes: ${report.description}` : undefined,
+          `Photos available: ${report.photoCount}`,
+          '',
+          'Please let us know if you need additional information from our organizers.',
+          '',
+          'Down East Cyclists',
+        ]
+          .filter((line): line is string => line !== undefined)
+          .join('\n');
+
+        return {
+          to: process.env.ONSLOW_PARKS_EMAIL ?? '',
+          subject,
+          body,
+          mailto: `mailto:${encodeURIComponent(
+            process.env.ONSLOW_PARKS_EMAIL ?? '',
+          )}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`,
+        };
+      }),
+  });
+}

--- a/app/api/admin/trail-maintenance/reports/[reportId]/notes/route.ts
+++ b/app/api/admin/trail-maintenance/reports/[reportId]/notes/route.ts
@@ -1,0 +1,49 @@
+import {Effect} from 'effect';
+import {NextRequest} from 'next/server';
+import {z} from 'zod';
+
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+import {DatabaseError, ValidationError} from '@/src/lib/effect/errors';
+import {addTrailMaintenanceNote} from '@/src/lib/trail-maintenance/repository';
+
+interface RouteContext {
+  readonly params: Promise<{readonly reportId: string}>;
+}
+
+const noteSchema = z.object({
+  note: z.string().trim().min(1).max(4000),
+});
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const {reportId} = await context.params;
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        const session = yield* admin.authorize(sessionCookie, 'trail-maintenance:manage');
+        const input = yield* Effect.tryPromise({
+          try: async () => noteSchema.parse(await request.json()),
+          catch: (error) =>
+            new ValidationError({
+              field: 'body',
+              message: error instanceof Error ? error.message : 'Invalid note',
+              cause: error,
+            }),
+        });
+        yield* Effect.tryPromise({
+          try: () =>
+            addTrailMaintenanceNote({
+              reportId,
+              note: input.note,
+              actor: {uid: session.uid, email: session.email},
+            }),
+          catch: (error) =>
+            new DatabaseError({
+              code: 'TRAIL_MAINTENANCE_NOTE_FAILED',
+              message: 'Failed to add note',
+              cause: error,
+            }),
+        });
+        return {ok: true};
+      }),
+  });
+}

--- a/app/api/admin/trail-maintenance/reports/[reportId]/route.ts
+++ b/app/api/admin/trail-maintenance/reports/[reportId]/route.ts
@@ -1,0 +1,71 @@
+import {Effect} from 'effect';
+import {NextRequest} from 'next/server';
+
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+import {DatabaseError, NotFoundError, ValidationError} from '@/src/lib/effect/errors';
+import {
+  getTrailMaintenanceReportDetail,
+  updateTrailMaintenanceReport,
+} from '@/src/lib/trail-maintenance/repository';
+import {trailMaintenanceUpdateSchema} from '@/src/lib/trail-maintenance/validation';
+
+interface RouteContext {
+  readonly params: Promise<{readonly reportId: string}>;
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const {reportId} = await context.params;
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        yield* admin.authorize(sessionCookie, 'trail-maintenance:manage');
+        const report = yield* Effect.tryPromise({
+          try: () => getTrailMaintenanceReportDetail(reportId),
+          catch: (error) =>
+            new DatabaseError({
+              code: 'TRAIL_MAINTENANCE_GET_FAILED',
+              message: 'Failed to load trail maintenance report',
+              cause: error,
+            }),
+        });
+        if (!report) {
+          return yield* Effect.fail(new NotFoundError({resource: 'Trail report', id: reportId}));
+        }
+        return report;
+      }),
+  });
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const {reportId} = await context.params;
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        const session = yield* admin.authorize(sessionCookie, 'trail-maintenance:manage');
+        const input = yield* Effect.tryPromise({
+          try: async () => trailMaintenanceUpdateSchema.parse(await request.json()),
+          catch: (error) =>
+            new ValidationError({
+              field: 'body',
+              message: error instanceof Error ? error.message : 'Invalid update',
+              cause: error,
+            }),
+        });
+        yield* Effect.tryPromise({
+          try: () =>
+            updateTrailMaintenanceReport({
+              reportId,
+              input,
+              actor: {uid: session.uid, email: session.email},
+            }),
+          catch: (error) =>
+            new DatabaseError({
+              code: 'TRAIL_MAINTENANCE_UPDATE_FAILED',
+              message: 'Failed to update trail maintenance report',
+              cause: error,
+            }),
+        });
+        return {ok: true};
+      }),
+  });
+}

--- a/app/api/admin/trail-maintenance/reports/route.ts
+++ b/app/api/admin/trail-maintenance/reports/route.ts
@@ -1,0 +1,42 @@
+import {Effect} from 'effect';
+import {NextRequest} from 'next/server';
+
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+import {DatabaseError, ValidationError} from '@/src/lib/effect/errors';
+import {listTrailMaintenanceReports} from '@/src/lib/trail-maintenance/repository';
+import {trailMaintenanceListQuerySchema} from '@/src/lib/trail-maintenance/validation';
+
+export async function GET(request: NextRequest) {
+  return handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        yield* admin.authorize(sessionCookie, 'trail-maintenance:manage');
+        const query = yield* Effect.try({
+          try: () =>
+            trailMaintenanceListQuerySchema.parse({
+              status: request.nextUrl.searchParams.get('status') || undefined,
+              priority: request.nextUrl.searchParams.get('priority') || undefined,
+              issueType: request.nextUrl.searchParams.get('issueType') || undefined,
+              page: request.nextUrl.searchParams.get('page') || undefined,
+              pageSize: request.nextUrl.searchParams.get('pageSize') || undefined,
+            }),
+          catch: (error) =>
+            new ValidationError({
+              field: 'query',
+              message: error instanceof Error ? error.message : 'Invalid filters',
+              cause: error,
+            }),
+        });
+
+        return yield* Effect.tryPromise({
+          try: () => listTrailMaintenanceReports(query),
+          catch: (error) =>
+            new DatabaseError({
+              code: 'TRAIL_MAINTENANCE_LIST_FAILED',
+              message: 'Failed to load trail maintenance reports',
+              cause: error,
+            }),
+        });
+      }),
+  });
+}

--- a/app/api/trail-maintenance/options/route.ts
+++ b/app/api/trail-maintenance/options/route.ts
@@ -1,0 +1,12 @@
+import {NextResponse} from 'next/server';
+
+import {getTrailMaintenanceOptions} from '@/src/lib/trail-maintenance/repository';
+
+export async function GET() {
+  try {
+    return NextResponse.json({trailSystems: await getTrailMaintenanceOptions()});
+  } catch (error) {
+    console.error('[TrailMaintenance] Failed to load options:', error);
+    return NextResponse.json({error: 'Failed to load trail options'}, {status: 500});
+  }
+}

--- a/app/api/trail-maintenance/reports/route.ts
+++ b/app/api/trail-maintenance/reports/route.ts
@@ -1,0 +1,101 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {TRAIL_MAINTENANCE_PHOTO_LIMIT} from '@/src/lib/trail-maintenance/constants';
+import {sendTrailMaintenanceNotification} from '@/src/lib/trail-maintenance/notifications';
+import {storeTrailMaintenancePhotos} from '@/src/lib/trail-maintenance/r2';
+import {
+  createTrailMaintenanceReport,
+  getTrailMaintenanceReportDetail,
+  getTrailMaintenanceReportRecipients,
+} from '@/src/lib/trail-maintenance/repository';
+import {verifyTrailMaintenanceTurnstile} from '@/src/lib/trail-maintenance/turnstile';
+import {publicTrailMaintenanceReportSchema} from '@/src/lib/trail-maintenance/validation';
+
+function getClientIp(request: NextRequest): string | null {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) return forwardedFor.split(',')[0]?.trim() || null;
+  return request.headers.get('x-real-ip');
+}
+
+function formValue(formData: FormData, key: string): string | undefined {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getPhotoFiles(formData: FormData): File[] {
+  return formData
+    .getAll('photos')
+    .filter((value): value is File => value instanceof File && value.size > 0)
+    .slice(0, TRAIL_MAINTENANCE_PHOTO_LIMIT);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const parsed = publicTrailMaintenanceReportSchema.safeParse({
+      issueType: formValue(formData, 'issueType'),
+      issueTypeOther: formValue(formData, 'issueTypeOther'),
+      observedAt: formValue(formData, 'observedAt'),
+      trailSystemSlug: formValue(formData, 'trailSystemSlug'),
+      trailSegmentSlug: formValue(formData, 'trailSegmentSlug'),
+      locationSource: formValue(formData, 'locationSource') || 'manual',
+      locationNotes: formValue(formData, 'locationNotes'),
+      latitude: formValue(formData, 'latitude'),
+      longitude: formValue(formData, 'longitude'),
+      locationAccuracyMeters: formValue(formData, 'locationAccuracyMeters'),
+      description: formValue(formData, 'description'),
+      reporterName: formValue(formData, 'reporterName'),
+      reporterContact: formValue(formData, 'reporterContact'),
+      turnstileToken:
+        formValue(formData, 'cf-turnstile-response') || formValue(formData, 'turnstileToken'),
+    });
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {error: parsed.error.issues[0]?.message || 'Invalid report'},
+        {status: 400},
+      );
+    }
+
+    const remoteIp = getClientIp(request);
+    const turnstile = await verifyTrailMaintenanceTurnstile({
+      token: parsed.data.turnstileToken,
+      remoteIp,
+    });
+    if (!turnstile.ok) {
+      return NextResponse.json({error: turnstile.reason || 'Bot check failed'}, {status: 403});
+    }
+
+    const publicId = crypto.randomUUID().replace(/-/g, '').slice(0, 12).toUpperCase();
+    const photos = await storeTrailMaintenancePhotos({
+      publicId,
+      files: getPhotoFiles(formData),
+    });
+
+    const created = await createTrailMaintenanceReport({
+      input: parsed.data,
+      photos,
+      publicId,
+      userAgent: request.headers.get('user-agent'),
+      remoteIp,
+    });
+
+    const report = await getTrailMaintenanceReportDetail(created.id);
+    if (report) {
+      const recipients = await getTrailMaintenanceReportRecipients();
+      await sendTrailMaintenanceNotification({report, recipients});
+    }
+
+    return NextResponse.json(
+      {
+        publicId: created.publicId,
+        reportUrl: `/report-trail-issue/${created.publicId}`,
+      },
+      {status: 201},
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to submit report';
+    console.error('[TrailMaintenance] Failed to submit report:', error);
+    return NextResponse.json({error: message}, {status: 500});
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,10 +7,9 @@ import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 import QrCodeScannerIcon from '@mui/icons-material/QrCodeScanner';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
-import RefreshIcon from '@mui/icons-material/Refresh';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import SyncAltIcon from '@mui/icons-material/SyncAlt';
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -20,8 +19,6 @@ import {
   Paper,
   Typography,
 } from '@mui/material';
-import {useMutation} from '@tanstack/react-query';
-import {Effect} from 'effect';
 import {useRouter} from 'next/navigation';
 import {useEffect, useState} from 'react';
 import {Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis} from 'recharts';
@@ -30,19 +27,18 @@ import {ActionLog} from '@/src/components/admin/ActionLog';
 import {MembershipManagement} from '@/src/components/admin/MembershipManagement';
 import {OrganizerManagement} from '@/src/components/admin/OrganizerManagement';
 import {ReconciliationTool} from '@/src/components/admin/ReconciliationTool';
+import {TrailMaintenanceManagement} from '@/src/components/admin/TrailMaintenanceManagement';
 import {useAuth} from '@/src/components/auth/AuthProvider';
 import TrailStatus from '@/src/components/TrailStatus';
 import TrailStatusEditor from '@/src/components/TrailStatusEditor';
 import type {StaffRole} from '@/src/lib/access-control';
-import {refreshStats} from '@/src/lib/effect/client-admin';
-import type {DatabaseError, UnauthorizedError} from '@/src/lib/effect/errors';
-import type {MembershipStats} from '@/src/lib/effect/schemas';
 
 type AdminSection =
   | 'overview'
   | 'members'
   | 'action-log'
   | 'trails'
+  | 'trail-maintenance'
   | 'reconciliation'
   | 'organizers';
 
@@ -72,6 +68,11 @@ const allSections: Array<{
   {id: 'members', label: 'Members', icon: <PeopleAltIcon fontSize="small" />},
   {id: 'action-log', label: 'Action Log', icon: <ReceiptLongIcon fontSize="small" />},
   {id: 'trails', label: 'Trail status', icon: <DirectionsBikeIcon fontSize="small" />},
+  {
+    id: 'trail-maintenance',
+    label: 'Maintenance',
+    icon: <ReportProblemIcon fontSize="small" />,
+  },
   {
     id: 'reconciliation',
     label: 'Reconciliation',
@@ -170,29 +171,6 @@ export default function DashboardPage() {
     trails: 1,
     events: 12,
     blogPosts: 36,
-  });
-
-  const refreshStatsMutation = useMutation<
-    MembershipStats,
-    DatabaseError | UnauthorizedError,
-    void
-  >({
-    mutationFn: () => Effect.runPromise(refreshStats()),
-    onSuccess: (data) => {
-      setDashboardStats((prev) => ({
-        ...prev,
-        totalMembers: data.totalMembers || 0,
-        activeMembers: data.activeMembers || 0,
-        expiredMembers: data.expiredMembers,
-        canceledMembers: data.canceledMembers,
-        individualCount: data.individualCount,
-        familyCount: data.familyCount,
-        yearlyRevenue: data.yearlyRevenue,
-        expiringSoonMembers: data.expiringSoonMembers,
-        newMembersThisMonth: data.newMembersThisMonth,
-        membershipGrowth: data.membershipGrowth,
-      }));
-    },
   });
 
   useEffect(() => {
@@ -297,10 +275,7 @@ export default function DashboardPage() {
   const sectionTitle = sections.find((item) => item.id === section)?.label || 'Overview';
 
   return (
-    <Box
-      className="dec-admin-page"
-      sx={{display: 'flex', minHeight: 'calc(100vh - 76px)', mt: '-76px', pt: '76px'}}
-    >
+    <Box className="dec-admin-page" sx={{display: 'flex', minHeight: 'calc(100vh - 76px)'}}>
       <Box
         component="aside"
         sx={{
@@ -401,41 +376,18 @@ export default function DashboardPage() {
       </Box>
 
       <Box sx={{flex: 1, minWidth: 0}}>
-        <Paper
-          square
+        <Box
           sx={{
-            position: 'sticky',
-            top: 76,
-            zIndex: 2,
             px: {xs: 2, md: 4},
-            py: 2.5,
+            py: {xs: 2, md: 2.5},
             borderBottom: '1px solid var(--dec-border)',
-            bgcolor: 'var(--dec-surface)',
-            display: 'flex',
-            justifyContent: 'space-between',
-            gap: 2,
-            alignItems: 'center',
+            bgcolor: 'var(--dec-admin-bg)',
           }}
         >
-          <Box>
-            <Typography variant="h2" sx={{fontSize: 32, lineHeight: 1}}>
-              {sectionTitle}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {dashboardStats.totalMembers} total · {dashboardStats.activeMembers} active
-            </Typography>
-          </Box>
-          <Button
-            variant="outlined"
-            startIcon={
-              refreshStatsMutation.isPending ? <CircularProgress size={18} /> : <RefreshIcon />
-            }
-            onClick={() => refreshStatsMutation.mutate()}
-            disabled={refreshStatsMutation.isPending}
-          >
-            Refresh
-          </Button>
-        </Paper>
+          <Typography variant="h2" sx={{fontSize: {xs: 28, md: 32}, lineHeight: 1}}>
+            {sectionTitle}
+          </Typography>
+        </Box>
 
         <Box
           sx={{
@@ -459,12 +411,6 @@ export default function DashboardPage() {
         </Box>
 
         <Box sx={{p: {xs: 2, md: 4}}}>
-          {refreshStatsMutation.error && (
-            <Alert severity="error" sx={{mb: 2}}>
-              {refreshStatsMutation.error.message}
-            </Alert>
-          )}
-
           {section === 'overview' && (
             <Box sx={{display: 'grid', gap: 3}}>
               <Box
@@ -573,6 +519,9 @@ export default function DashboardPage() {
                       <Button variant="outlined" onClick={() => setSection('trails')}>
                         Update trail status
                       </Button>
+                      <Button variant="outlined" onClick={() => setSection('trail-maintenance')}>
+                        Review trail reports
+                      </Button>
                       {staffRole === 'admin' && (
                         <Button variant="outlined" onClick={() => setSection('reconciliation')}>
                           Run reconciliation
@@ -602,6 +551,8 @@ export default function DashboardPage() {
               </Paper>
             </Box>
           )}
+
+          {section === 'trail-maintenance' && <TrailMaintenanceManagement />}
 
           {section === 'reconciliation' && staffRole === 'admin' && <ReconciliationTool />}
 

--- a/app/report-trail-issue/[publicId]/page.tsx
+++ b/app/report-trail-issue/[publicId]/page.tsx
@@ -1,0 +1,195 @@
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Container,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import Link from 'next/link';
+import {notFound} from 'next/navigation';
+
+import {getPublicTrailMaintenanceReport} from '@/src/lib/trail-maintenance/repository';
+
+export const dynamic = 'force-dynamic';
+
+interface ReportTrailIssueDetailPageProps {
+  readonly params: Promise<{readonly publicId: string}>;
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function mapUrl(latitude: number, longitude: number): string {
+  const delta = 0.004;
+  const bbox = [longitude - delta, latitude - delta, longitude + delta, latitude + delta].join(',');
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(
+    bbox,
+  )}&layer=mapnik&marker=${encodeURIComponent(`${latitude},${longitude}`)}`;
+}
+
+export default async function ReportTrailIssueDetailPage({
+  params,
+}: ReportTrailIssueDetailPageProps) {
+  const {publicId} = await params;
+  const report = await getPublicTrailMaintenanceReport(publicId);
+  if (!report) notFound();
+
+  const hasCoordinates = report.latitude !== null && report.longitude !== null;
+
+  return (
+    <Container maxWidth="md" sx={{py: {xs: 4, md: 7}}}>
+      <Paper className="dec-card" sx={{p: {xs: 2.5, md: 4}}}>
+        <Stack spacing={3}>
+          <Alert severity="success" icon={<CheckCircleIcon />}>
+            Report submitted. Organizers can now review and track this issue.
+          </Alert>
+
+          <Box>
+            <Typography variant="overline" color="text.secondary" sx={{fontWeight: 800}}>
+              Report {report.publicId}
+            </Typography>
+            <Typography variant="h1" sx={{fontSize: {xs: 38, md: 56}, lineHeight: 1.05, mt: 0.5}}>
+              {report.issueTypeLabel}
+            </Typography>
+          </Box>
+
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            <Chip label={report.statusLabel} color="primary" />
+            <Chip label={`Priority: ${report.priorityLabel}`} variant="outlined" />
+            <Chip label={report.trailSystemName} variant="outlined" />
+            {report.trailSegmentName && <Chip label={report.trailSegmentName} variant="outlined" />}
+          </Stack>
+
+          <Divider />
+
+          <Box sx={{display: 'grid', gap: 2}}>
+            <Box>
+              <Typography variant="subtitle2" color="text.secondary">
+                Submitted
+              </Typography>
+              <Typography>{formatDateTime(report.createdAt)}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="subtitle2" color="text.secondary">
+                Observed
+              </Typography>
+              <Typography>{formatDateTime(report.observedAt)}</Typography>
+            </Box>
+            {report.resolvedAt && (
+              <Box>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Resolved
+                </Typography>
+                <Typography>{formatDateTime(report.resolvedAt)}</Typography>
+              </Box>
+            )}
+          </Box>
+
+          {report.description && (
+            <Box>
+              <Typography variant="h2" sx={{fontSize: 24, mb: 1}}>
+                Details
+              </Typography>
+              <Typography sx={{whiteSpace: 'pre-wrap'}}>{report.description}</Typography>
+            </Box>
+          )}
+
+          <Box>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
+              <LocationOnIcon color="primary" />
+              <Typography variant="h2" sx={{fontSize: 24}}>
+                Location
+              </Typography>
+            </Stack>
+            {report.locationNotes && (
+              <Typography sx={{whiteSpace: 'pre-wrap', mb: 2}}>{report.locationNotes}</Typography>
+            )}
+            {hasCoordinates ? (
+              <Box
+                component="iframe"
+                title={`Map for trail issue report ${report.publicId}`}
+                src={mapUrl(report.latitude, report.longitude)}
+                sx={{
+                  width: '100%',
+                  height: {xs: 260, md: 360},
+                  border: 0,
+                  borderRadius: 1,
+                }}
+              />
+            ) : (
+              <Typography color="text.secondary">
+                No GPS coordinates were submitted for this report.
+              </Typography>
+            )}
+          </Box>
+
+          <Box>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{mb: 1}}>
+              <PhotoCameraIcon color="primary" />
+              <Typography variant="h2" sx={{fontSize: 24}}>
+                Photo
+              </Typography>
+            </Stack>
+            {report.photos.length > 0 ? (
+              <Stack spacing={2}>
+                {report.photos.map((photo) =>
+                  photo.url ? (
+                    <Box
+                      key={photo.id}
+                      component="img"
+                      src={photo.url}
+                      alt={photo.originalFilename || `Trail issue report ${report.publicId}`}
+                      sx={{
+                        width: '100%',
+                        maxHeight: 520,
+                        objectFit: 'contain',
+                        bgcolor: 'grey.100',
+                        borderRadius: 1,
+                      }}
+                    />
+                  ) : (
+                    <Alert key={photo.id} severity="info">
+                      Photo preview is not available right now.
+                    </Alert>
+                  ),
+                )}
+              </Stack>
+            ) : (
+              <Typography color="text.secondary">
+                No photo was submitted with this report.
+              </Typography>
+            )}
+          </Box>
+
+          <Divider />
+
+          <Stack direction={{xs: 'column', sm: 'row'}} spacing={1.5}>
+            <Button
+              component={Link}
+              href="/report-trail-issue"
+              variant="contained"
+              startIcon={<ReportProblemIcon />}
+            >
+              Submit another report
+            </Button>
+            <Button component={Link} href="/" variant="outlined">
+              Return home
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/app/report-trail-issue/page.tsx
+++ b/app/report-trail-issue/page.tsx
@@ -1,0 +1,18 @@
+import {Box, CircularProgress} from '@mui/material';
+import {Suspense} from 'react';
+
+import {PublicTrailIssueReportForm} from '@/src/components/trail-maintenance/PublicTrailIssueReportForm';
+
+export default function ReportTrailIssuePage() {
+  return (
+    <Suspense
+      fallback={
+        <Box sx={{display: 'grid', placeItems: 'center', minHeight: 360}}>
+          <CircularProgress />
+        </Box>
+      }
+    >
+      <PublicTrailIssueReportForm />
+    </Suspense>
+  );
+}

--- a/app/trails/b3/page.tsx
+++ b/app/trails/b3/page.tsx
@@ -39,17 +39,26 @@ export default async function B3() {
             Beginner flow and intermediate single-track inside Onslow County&apos;s Burton Park
             area, open dawn to dusk when trail conditions allow.
           </p>
-          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <div className="mt-8 grid max-w-3xl grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
             <a
               href="https://maps.google.com/?q=Big+Branch+Bike+Park"
               target="_blank"
               rel="noopener noreferrer"
-              className="dec-primary-button"
+              className="dec-primary-button min-h-14 whitespace-nowrap px-4 text-base leading-none"
             >
               Get directions ↗
             </a>
-            <Link href="/join" className="dec-secondary-button">
+            <Link
+              href="/join"
+              className="dec-secondary-button min-h-14 whitespace-nowrap px-4 text-base leading-none"
+            >
               Support the trail
+            </Link>
+            <Link
+              href="/report-trail-issue?system=big-branch-bike-park"
+              className="dec-secondary-button min-h-14 whitespace-nowrap px-4 text-base leading-none sm:col-span-2 xl:col-span-1"
+            >
+              ⚠️ Report Trail Issue
             </Link>
           </div>
         </div>

--- a/drizzle/0004_lame_lethal_legion.sql
+++ b/drizzle/0004_lame_lethal_legion.sql
@@ -1,0 +1,146 @@
+CREATE TYPE "public"."trail_issue_event_type" AS ENUM('created', 'status_changed', 'priority_changed', 'assigned', 'note_added', 'county_email_generated', 'county_email_sent', 'resolved', 'reopened');--> statement-breakpoint
+CREATE TYPE "public"."trail_issue_priority" AS ENUM('low', 'normal', 'high', 'urgent');--> statement-breakpoint
+CREATE TYPE "public"."trail_issue_status" AS ENUM('new', 'triaged', 'assigned', 'county_needed', 'county_contacted', 'in_progress', 'resolved', 'closed_no_action', 'duplicate');--> statement-breakpoint
+CREATE TYPE "public"."trail_issue_type" AS ENUM('trail_obstruction', 'erosion_or_hole', 'standing_water_or_drainage', 'overgrown_vegetation', 'damaged_feature', 'missing_or_damaged_sign', 'trash_or_vandalism', 'other');--> statement-breakpoint
+CREATE TYPE "public"."trail_location_source" AS ENUM('browser_geolocation', 'map_pin', 'manual', 'qr_prefill');--> statement-breakpoint
+CREATE TABLE "trail_maintenance_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"report_id" uuid NOT NULL,
+	"event_type" "trail_issue_event_type" NOT NULL,
+	"actor_user_id" uuid,
+	"actor_label" varchar(255) NOT NULL,
+	"details" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "trail_maintenance_notes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"report_id" uuid NOT NULL,
+	"author_user_id" uuid,
+	"author_email" varchar(255),
+	"note" text NOT NULL,
+	"is_public" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "trail_maintenance_photos" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"report_id" uuid NOT NULL,
+	"bucket_name" varchar(160) NOT NULL,
+	"object_key" text NOT NULL,
+	"original_filename" varchar(255),
+	"content_type" varchar(120) NOT NULL,
+	"byte_size" integer NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "trail_maintenance_reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"public_id" varchar(24) NOT NULL,
+	"trail_system_id" uuid NOT NULL,
+	"trail_segment_id" uuid,
+	"issue_type" "trail_issue_type" NOT NULL,
+	"issue_type_other" varchar(160),
+	"status" "trail_issue_status" DEFAULT 'new' NOT NULL,
+	"priority" "trail_issue_priority" DEFAULT 'normal' NOT NULL,
+	"observed_at" timestamp with time zone NOT NULL,
+	"description" text,
+	"location_source" "trail_location_source" DEFAULT 'manual' NOT NULL,
+	"location_notes" text,
+	"latitude" double precision,
+	"longitude" double precision,
+	"location_accuracy_meters" double precision,
+	"reporter_name" varchar(160),
+	"reporter_contact" varchar(255),
+	"user_agent" text,
+	"submitter_ip_hash" varchar(128),
+	"assigned_to_user_id" uuid,
+	"county_email_generated_at" timestamp with time zone,
+	"county_email_sent_at" timestamp with time zone,
+	"resolved_by_user_id" uuid,
+	"resolved_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "trail_maintenance_reports_public_id_unique" UNIQUE("public_id")
+);
+--> statement-breakpoint
+CREATE TABLE "trail_segments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"trail_system_id" uuid NOT NULL,
+	"slug" varchar(80) NOT NULL,
+	"name" varchar(160) NOT NULL,
+	"color_label" varchar(80),
+	"is_active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "trail_systems" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" varchar(80) NOT NULL,
+	"name" varchar(160) NOT NULL,
+	"description" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "trail_systems_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "trail_maintenance_events" ADD CONSTRAINT "trail_maintenance_events_report_id_trail_maintenance_reports_id_fk" FOREIGN KEY ("report_id") REFERENCES "public"."trail_maintenance_reports"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_events" ADD CONSTRAINT "trail_maintenance_events_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_notes" ADD CONSTRAINT "trail_maintenance_notes_report_id_trail_maintenance_reports_id_fk" FOREIGN KEY ("report_id") REFERENCES "public"."trail_maintenance_reports"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_notes" ADD CONSTRAINT "trail_maintenance_notes_author_user_id_users_id_fk" FOREIGN KEY ("author_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_photos" ADD CONSTRAINT "trail_maintenance_photos_report_id_trail_maintenance_reports_id_fk" FOREIGN KEY ("report_id") REFERENCES "public"."trail_maintenance_reports"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_reports" ADD CONSTRAINT "trail_maintenance_reports_trail_system_id_trail_systems_id_fk" FOREIGN KEY ("trail_system_id") REFERENCES "public"."trail_systems"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_reports" ADD CONSTRAINT "trail_maintenance_reports_trail_segment_id_trail_segments_id_fk" FOREIGN KEY ("trail_segment_id") REFERENCES "public"."trail_segments"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_reports" ADD CONSTRAINT "trail_maintenance_reports_assigned_to_user_id_users_id_fk" FOREIGN KEY ("assigned_to_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_maintenance_reports" ADD CONSTRAINT "trail_maintenance_reports_resolved_by_user_id_users_id_fk" FOREIGN KEY ("resolved_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "trail_segments" ADD CONSTRAINT "trail_segments_trail_system_id_trail_systems_id_fk" FOREIGN KEY ("trail_system_id") REFERENCES "public"."trail_systems"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "trail_maintenance_events_report_idx" ON "trail_maintenance_events" USING btree ("report_id");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_events_created_at_idx" ON "trail_maintenance_events" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_notes_report_idx" ON "trail_maintenance_notes" USING btree ("report_id");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_notes_created_at_idx" ON "trail_maintenance_notes" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_photos_report_idx" ON "trail_maintenance_photos" USING btree ("report_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "trail_maintenance_photos_object_key_idx" ON "trail_maintenance_photos" USING btree ("object_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "trail_maintenance_reports_public_id_idx" ON "trail_maintenance_reports" USING btree ("public_id");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_reports_status_idx" ON "trail_maintenance_reports" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_reports_priority_idx" ON "trail_maintenance_reports" USING btree ("priority");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_reports_created_at_idx" ON "trail_maintenance_reports" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "trail_maintenance_reports_system_status_idx" ON "trail_maintenance_reports" USING btree ("trail_system_id","status");--> statement-breakpoint
+CREATE UNIQUE INDEX "trail_segments_system_slug_idx" ON "trail_segments" USING btree ("trail_system_id","slug");--> statement-breakpoint
+CREATE INDEX "trail_segments_system_active_sort_idx" ON "trail_segments" USING btree ("trail_system_id","is_active","sort_order");--> statement-breakpoint
+CREATE UNIQUE INDEX "trail_systems_slug_idx" ON "trail_systems" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "trail_systems_active_sort_idx" ON "trail_systems" USING btree ("is_active","sort_order");--> statement-breakpoint
+INSERT INTO "trail_systems" ("slug", "name", "description", "is_active", "sort_order")
+VALUES (
+  'big-branch-bike-park',
+  'Big Branch Bike Park',
+  'Big Branch Bike Park trail maintenance reports',
+  true,
+  0
+)
+ON CONFLICT ("slug") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "description" = EXCLUDED."description",
+  "is_active" = EXCLUDED."is_active",
+  "sort_order" = EXCLUDED."sort_order",
+  "updated_at" = now();--> statement-breakpoint
+INSERT INTO "trail_segments" ("trail_system_id", "slug", "name", "color_label", "is_active", "sort_order")
+SELECT "trail_systems"."id", "segments"."slug", "segments"."name", "segments"."color_label", true, "segments"."sort_order"
+FROM "trail_systems"
+CROSS JOIN (
+  VALUES
+    ('phase-1-green-ricochet', 'Phase 1 Green (Ricochet)', 'Green', 0),
+    ('phase-1-blue-ridge-runners-loop', 'Phase 1 Blue (Ridge Runners Loop)', 'Blue', 1),
+    ('phase-2-blue-trail-dynamic', 'Phase 2 Blue (Trail Dynamic)', 'Blue', 2)
+) AS "segments"("slug", "name", "color_label", "sort_order")
+WHERE "trail_systems"."slug" = 'big-branch-bike-park'
+ON CONFLICT ("trail_system_id", "slug") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "color_label" = EXCLUDED."color_label",
+  "is_active" = EXCLUDED."is_active",
+  "sort_order" = EXCLUDED."sort_order",
+  "updated_at" = now();

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2143 @@
+{
+  "id": "7070022d-ac27-411e-bc00-6dcc0de61dde",
+  "prevId": "bf87bf1e-0db5-490b-9980-ca0c36607d4f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_email": {
+          "name": "performed_by_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_log": {
+      "name": "email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_type": {
+          "name": "delivery_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_key": {
+          "name": "campaign_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by": {
+          "name": "sent_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_by_email": {
+          "name": "sent_by_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_log_user_type_campaign_idx": {
+          "name": "email_log_user_type_campaign_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_log_membership_idx": {
+          "name": "email_log_membership_idx",
+          "columns": [
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_log_created_at_idx": {
+          "name": "email_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_log_user_id_users_id_fk": {
+          "name": "email_log_user_id_users_id_fk",
+          "tableFrom": "email_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_log_membership_id_memberships_id_fk": {
+          "name": "email_log_membership_id_memberships_id_fk",
+          "tableFrom": "email_log",
+          "tableTo": "memberships",
+          "columnsFrom": ["membership_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup_events": {
+      "name": "meetup_events",
+      "schema": "",
+      "columns": {
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_events_start_date_idx": {
+          "name": "meetup_events_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_cards": {
+      "name": "membership_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_number": {
+          "name": "membership_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_name": {
+          "name": "member_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "plan_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qr_code_data": {
+          "name": "qr_code_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_cards_user_id_idx": {
+          "name": "membership_cards_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "membership_cards_membership_id_idx": {
+          "name": "membership_cards_membership_id_idx",
+          "columns": [
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "membership_cards_user_id_users_id_fk": {
+          "name": "membership_cards_user_id_users_id_fk",
+          "tableFrom": "membership_cards",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "membership_cards_membership_id_memberships_id_fk": {
+          "name": "membership_cards_membership_id_memberships_id_fk",
+          "tableFrom": "membership_cards",
+          "tableTo": "memberships",
+          "columnsFrom": ["membership_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "membership_cards_membership_number_unique": {
+          "name": "membership_cards_membership_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["membership_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_counters": {
+      "name": "membership_counters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_number": {
+          "name": "last_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_counters_year_idx": {
+          "name": "membership_counters_year_idx",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_plans": {
+      "name": "membership_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "plan_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "membership_plans_stripe_price_idx": {
+          "name": "membership_plans_stripe_price_idx",
+          "columns": [
+            {
+              "expression": "stripe_price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_stats": {
+      "name": "membership_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'memberships'"
+        },
+        "total_members": {
+          "name": "total_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_members": {
+          "name": "active_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expired_members": {
+          "name": "expired_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "canceled_members": {
+          "name": "canceled_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "individual_count": {
+          "name": "individual_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "family_count": {
+          "name": "family_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_revenue": {
+          "name": "monthly_revenue",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "yearly_revenue": {
+          "name": "yearly_revenue",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "plan_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'incomplete'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_renew": {
+          "name": "auto_renew",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_user_id_idx": {
+          "name": "memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_stripe_sub_idx": {
+          "name": "memberships_stripe_sub_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_status_end_date_idx": {
+          "name": "memberships_status_end_date_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_status_idx": {
+          "name": "memberships_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_maintenance_events": {
+      "name": "trail_maintenance_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "trail_issue_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_maintenance_events_report_idx": {
+          "name": "trail_maintenance_events_report_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_maintenance_events_created_at_idx": {
+          "name": "trail_maintenance_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_maintenance_events_report_id_trail_maintenance_reports_id_fk": {
+          "name": "trail_maintenance_events_report_id_trail_maintenance_reports_id_fk",
+          "tableFrom": "trail_maintenance_events",
+          "tableTo": "trail_maintenance_reports",
+          "columnsFrom": ["report_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trail_maintenance_events_actor_user_id_users_id_fk": {
+          "name": "trail_maintenance_events_actor_user_id_users_id_fk",
+          "tableFrom": "trail_maintenance_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_maintenance_notes": {
+      "name": "trail_maintenance_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_maintenance_notes_report_idx": {
+          "name": "trail_maintenance_notes_report_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_maintenance_notes_created_at_idx": {
+          "name": "trail_maintenance_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_maintenance_notes_report_id_trail_maintenance_reports_id_fk": {
+          "name": "trail_maintenance_notes_report_id_trail_maintenance_reports_id_fk",
+          "tableFrom": "trail_maintenance_notes",
+          "tableTo": "trail_maintenance_reports",
+          "columnsFrom": ["report_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trail_maintenance_notes_author_user_id_users_id_fk": {
+          "name": "trail_maintenance_notes_author_user_id_users_id_fk",
+          "tableFrom": "trail_maintenance_notes",
+          "tableTo": "users",
+          "columnsFrom": ["author_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_maintenance_photos": {
+      "name": "trail_maintenance_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_name": {
+          "name": "bucket_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_maintenance_photos_report_idx": {
+          "name": "trail_maintenance_photos_report_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_maintenance_photos_object_key_idx": {
+          "name": "trail_maintenance_photos_object_key_idx",
+          "columns": [
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_maintenance_photos_report_id_trail_maintenance_reports_id_fk": {
+          "name": "trail_maintenance_photos_report_id_trail_maintenance_reports_id_fk",
+          "tableFrom": "trail_maintenance_photos",
+          "tableTo": "trail_maintenance_reports",
+          "columnsFrom": ["report_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_maintenance_reports": {
+      "name": "trail_maintenance_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_system_id": {
+          "name": "trail_system_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trail_segment_id": {
+          "name": "trail_segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "trail_issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type_other": {
+          "name": "issue_type_other",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "trail_issue_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "trail_issue_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_source": {
+          "name": "location_source",
+          "type": "trail_location_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "location_notes": {
+          "name": "location_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_accuracy_meters": {
+          "name": "location_accuracy_meters",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_name": {
+          "name": "reporter_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_contact": {
+          "name": "reporter_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_ip_hash": {
+          "name": "submitter_ip_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to_user_id": {
+          "name": "assigned_to_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "county_email_generated_at": {
+          "name": "county_email_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "county_email_sent_at": {
+          "name": "county_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_maintenance_reports_public_id_idx": {
+          "name": "trail_maintenance_reports_public_id_idx",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_maintenance_reports_status_idx": {
+          "name": "trail_maintenance_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_maintenance_reports_priority_idx": {
+          "name": "trail_maintenance_reports_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_maintenance_reports_created_at_idx": {
+          "name": "trail_maintenance_reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_maintenance_reports_system_status_idx": {
+          "name": "trail_maintenance_reports_system_status_idx",
+          "columns": [
+            {
+              "expression": "trail_system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_maintenance_reports_trail_system_id_trail_systems_id_fk": {
+          "name": "trail_maintenance_reports_trail_system_id_trail_systems_id_fk",
+          "tableFrom": "trail_maintenance_reports",
+          "tableTo": "trail_systems",
+          "columnsFrom": ["trail_system_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "trail_maintenance_reports_trail_segment_id_trail_segments_id_fk": {
+          "name": "trail_maintenance_reports_trail_segment_id_trail_segments_id_fk",
+          "tableFrom": "trail_maintenance_reports",
+          "tableTo": "trail_segments",
+          "columnsFrom": ["trail_segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trail_maintenance_reports_assigned_to_user_id_users_id_fk": {
+          "name": "trail_maintenance_reports_assigned_to_user_id_users_id_fk",
+          "tableFrom": "trail_maintenance_reports",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_to_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trail_maintenance_reports_resolved_by_user_id_users_id_fk": {
+          "name": "trail_maintenance_reports_resolved_by_user_id_users_id_fk",
+          "tableFrom": "trail_maintenance_reports",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_maintenance_reports_public_id_unique": {
+          "name": "trail_maintenance_reports_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["public_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_segments": {
+      "name": "trail_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trail_system_id": {
+          "name": "trail_system_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_label": {
+          "name": "color_label",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_segments_system_slug_idx": {
+          "name": "trail_segments_system_slug_idx",
+          "columns": [
+            {
+              "expression": "trail_system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_segments_system_active_sort_idx": {
+          "name": "trail_segments_system_active_sort_idx",
+          "columns": [
+            {
+              "expression": "trail_system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_segments_trail_system_id_trail_systems_id_fk": {
+          "name": "trail_segments_trail_system_id_trail_systems_id_fk",
+          "tableFrom": "trail_segments",
+          "tableTo": "trail_systems",
+          "columnsFrom": ["trail_system_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_systems": {
+      "name": "trail_systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_systems_slug_idx": {
+          "name": "trail_systems_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_systems_active_sort_idx": {
+          "name": "trail_systems_active_sort_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trail_systems_slug_unique": {
+          "name": "trail_systems_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street": {
+          "name": "address_street",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_stripe_customer_idx": {
+          "name": "users_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_firebase_uid_unique": {
+          "name": "users_firebase_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["firebase_uid"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_events_type_idx": {
+          "name": "webhook_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_idx": {
+          "name": "webhook_events_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "MEMBER_CREATED",
+        "MEMBER_UPDATED",
+        "MEMBER_DELETED",
+        "MEMBERSHIP_EXTENDED",
+        "MEMBERSHIP_PAUSED",
+        "EMAIL_CHANGED",
+        "STRIPE_SYNCED",
+        "REFUND_ISSUED",
+        "BULK_IMPORT",
+        "ADMIN_ROLE_CHANGE",
+        "MEMBERSHIP_ADJUSTMENT",
+        "RENEWAL_EMAIL_SENT",
+        "RENEWAL_EMAIL_RESENT",
+        "AUTOMATED_RENEWAL_EMAIL_SENT",
+        "RECONCILIATION"
+      ]
+    },
+    "public.membership_status": {
+      "name": "membership_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "past_due",
+        "canceled",
+        "incomplete",
+        "incomplete_expired",
+        "trialing",
+        "unpaid",
+        "deleted",
+        "complimentary",
+        "legacy"
+      ]
+    },
+    "public.plan_interval": {
+      "name": "plan_interval",
+      "schema": "public",
+      "values": ["year", "month"]
+    },
+    "public.plan_type": {
+      "name": "plan_type",
+      "schema": "public",
+      "values": ["individual", "family"]
+    },
+    "public.trail_issue_event_type": {
+      "name": "trail_issue_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "status_changed",
+        "priority_changed",
+        "assigned",
+        "note_added",
+        "county_email_generated",
+        "county_email_sent",
+        "resolved",
+        "reopened"
+      ]
+    },
+    "public.trail_issue_priority": {
+      "name": "trail_issue_priority",
+      "schema": "public",
+      "values": ["low", "normal", "high", "urgent"]
+    },
+    "public.trail_issue_status": {
+      "name": "trail_issue_status",
+      "schema": "public",
+      "values": [
+        "new",
+        "triaged",
+        "assigned",
+        "county_needed",
+        "county_contacted",
+        "in_progress",
+        "resolved",
+        "closed_no_action",
+        "duplicate"
+      ]
+    },
+    "public.trail_issue_type": {
+      "name": "trail_issue_type",
+      "schema": "public",
+      "values": [
+        "trail_obstruction",
+        "erosion_or_hole",
+        "standing_water_or_drainage",
+        "overgrown_vegetation",
+        "damaged_feature",
+        "missing_or_damaged_sign",
+        "trash_or_vandalism",
+        "other"
+      ]
+    },
+    "public.trail_location_source": {
+      "name": "trail_location_source",
+      "schema": "public",
+      "values": ["browser_geolocation", "map_pin", "manual", "qr_prefill"]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": ["processing", "completed", "failed"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1785003008695,
       "tag": "0003_happy_veda",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1785007477217,
+      "tag": "0004_lame_lethal_legion",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const path = require('path');
 const nextConfig = {
   // Configuration for Netlify deployment
   distDir: '.next',
+  outputFileTracingRoot: __dirname,
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-typed": "^2.0.12",
     "recharts": "^3.9.2",
     "remark-gfm": "^4.0.1",
-    "resend": "^6.9.3",
+    "resend": "^6.18.0",
     "stripe": "^20.1.2",
     "zod": "^3.24.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       resend:
-        specifier: ^6.9.3
-        version: 6.9.3
+        specifier: ^6.18.0
+        version: 6.18.0
       stripe:
         specifier: ^20.1.2
         version: 20.1.2(@types/node@20.19.25)
@@ -473,11 +473,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.11':
     resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
@@ -1446,105 +1446,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1989,28 +1973,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.18':
     resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.18':
     resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.18':
     resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.18':
     resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
@@ -2132,25 +2112,21 @@ packages:
     resolution: {integrity: sha512-ItPDOPoQ0wLj/s8osc5ch57uUcA1Wk8r0YdO8vLRpXA3UNg7KPOm1vdbkIZRRiSUphZcuX5ioOEetEK8H7RlTw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/linux-arm64-musl@0.24.0':
     resolution: {integrity: sha512-JkQO3WnQjQTJONx8nxdgVBfl6BBFfpp9bKhChYhWeakwJdr7QPOAWJ/v3FGZfr0TbqINwnNR74aVZayDDRyXEA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/linux-x64-gnu@0.24.0':
     resolution: {integrity: sha512-N/SXlFO+2kak5gMt0oxApi0WXQDhwA0PShR0UbkY0PwtHjfSiDqJSOumyNqgQVoroKr1GNnoRmUqjZIz6DKIcw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/linux-x64-musl@0.24.0':
     resolution: {integrity: sha512-WM0pek5YDCQf50XQ7GLCE9sMBCMPW/NPAEPH/Hx6Qyir37lEsP4rUmSECo/QFNTU6KBc9NnsviAyJruWPpCMXw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/win32-arm64@0.24.0':
     resolution: {integrity: sha512-vFCseli1KWtwdHrVlT/jWfZ8jP8oYpnPPEjI23mPLW8K/6GEJmmvy0PZP5NpWUFNTzX0lqie58XnrATJYAe9Xw==}
@@ -2176,25 +2152,21 @@ packages:
     resolution: {integrity: sha512-qocBkvS2V6rH0t9AT3DfQunMnj3xkM7srs5/Ycj2j5ZqMoaWd/FxHNVJDFP++35roKSvsRJoS0mtA8/77jqm6Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.39.0':
     resolution: {integrity: sha512-arZzAc1PPcz9epvGBBCMHICeyQloKtHX3eoOe62B3Dskn7gf6Q14wnDHr1r9Vp4vtcBATNq6HlKV14smdlC/qA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.39.0':
     resolution: {integrity: sha512-ZVt5qsECpuNprdWxAPpDBwoixr1VTcZ4qAEQA2l/wmFyVPDYFD3oBY/SWACNnWBddMrswjTg9O8ALxYWoEpmXw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.39.0':
     resolution: {integrity: sha512-pB0hlGyKPbxr9NMIV783lD6cWL3MpaqnZRM9MWni4yBdHPTKyFNYdg5hGD0Bwg+UP4S2rOevq/+OO9x9Bi7E6g==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/win32-arm64@1.39.0':
     resolution: {integrity: sha512-Gg2SFaJohI9+tIQVKXlPw3FsPQFi/eCSWiCgwPtPn5uzQxHRTeQEZKuluz1fuzR5U70TXubb2liZi4Dgl8LJQA==}
@@ -2235,42 +2207,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.1':
     resolution: {integrity: sha512-RJxlQQLkaMMIuWRozy+z2vEqbaQlCuaCgVZIUCzQLYggY22LZbP5Y1+ia+FD724Ids9e+XIyOLXLrLgQSHIthw==}
@@ -2416,85 +2382,71 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -2991,49 +2943,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5200,7 +5144,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -6986,8 +6930,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postal-mime@2.7.3:
-    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
+  postal-mime@2.7.5:
+    resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -7375,8 +7319,8 @@ packages:
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
-  resend@6.9.3:
-    resolution: {integrity: sha512-GRXjH9XZBJA+daH7bBVDuTShr22iWCxXA8P7t495G4dM/RC+d+3gHBK/6bz9K6Vpcq11zRQKmD+B+jECwQlyGQ==}
+  resend@6.18.0:
+    resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -7924,9 +7868,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  svix@1.84.1:
-    resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
-
   symbol-observable@1.2.0:
     resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
     engines: {node: '>=0.10.0'}
@@ -8343,11 +8284,6 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -13248,7 +13184,7 @@ snapshots:
       '@typescript-eslint/parser': 8.54.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -13268,7 +13204,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
@@ -13283,14 +13219,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13305,7 +13241,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16198,7 +16134,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postal-mime@2.7.3: {}
+  postal-mime@2.7.5: {}
 
   postcss-import@15.1.0(postcss@8.5.3):
     dependencies:
@@ -16648,10 +16584,10 @@ snapshots:
 
   reselect@5.2.0: {}
 
-  resend@6.9.3:
+  resend@6.18.0:
     dependencies:
-      postal-mime: 2.7.3
-      svix: 1.84.1
+      postal-mime: 2.7.5
+      standardwebhooks: 1.0.0
 
   resolve-alpn@1.2.1: {}
 
@@ -17282,11 +17218,6 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.4.3
 
-  svix@1.84.1:
-    dependencies:
-      standardwebhooks: 1.0.0
-      uuid: 10.0.0
-
   symbol-observable@1.2.0: {}
 
   system-architecture@0.1.0: {}
@@ -17733,8 +17664,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 

--- a/src/__tests__/lib/trail-maintenance-validation.test.ts
+++ b/src/__tests__/lib/trail-maintenance-validation.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it} from 'vitest';
+
+import {publicTrailMaintenanceReportSchema} from '@/src/lib/trail-maintenance/validation';
+
+const baseReport = {
+  issueType: 'trail_obstruction',
+  observedAt: '2026-07-25T10:00',
+  trailSystemSlug: 'big-branch-bike-park',
+  trailSegmentSlug: 'phase-1-green-ricochet',
+  locationSource: 'manual',
+  locationNotes: 'Near the first bridge',
+};
+
+describe('publicTrailMaintenanceReportSchema', () => {
+  it('accepts a report with manual location notes', () => {
+    const result = publicTrailMaintenanceReportSchema.safeParse(baseReport);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a report with GPS coordinates instead of location notes', () => {
+    const result = publicTrailMaintenanceReportSchema.safeParse({
+      ...baseReport,
+      locationNotes: '',
+      locationSource: 'browser_geolocation',
+      latitude: '34.754',
+      longitude: '-77.43',
+      locationAccuracyMeters: '18',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a report without notes or coordinates', () => {
+    const result = publicTrailMaintenanceReportSchema.safeParse({
+      ...baseReport,
+      locationNotes: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('requires an issue description when issue type is other', () => {
+    const result = publicTrailMaintenanceReportSchema.safeParse({
+      ...baseReport,
+      issueType: 'other',
+      issueTypeOther: '',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects coordinates outside valid ranges', () => {
+    const result = publicTrailMaintenanceReportSchema.safeParse({
+      ...baseReport,
+      locationSource: 'browser_geolocation',
+      latitude: '100',
+      longitude: '-200',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/components/admin/TrailMaintenanceManagement.tsx
+++ b/src/components/admin/TrailMaintenanceManagement.tsx
@@ -1,0 +1,494 @@
+'use client';
+
+import EmailIcon from '@mui/icons-material/Email';
+import MapIcon from '@mui/icons-material/Map';
+import NoteAddIcon from '@mui/icons-material/NoteAdd';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import Grid from '@mui/material/Grid2';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useMemo, useState} from 'react';
+
+import {
+  trailIssuePriorities,
+  trailIssuePriorityLabels,
+  trailIssueStatuses,
+  trailIssueStatusLabels,
+  type TrailIssuePriority,
+  type TrailIssueStatus,
+} from '@/src/lib/trail-maintenance/constants';
+import type {
+  TrailMaintenanceListResult,
+  TrailMaintenanceReportDetail,
+} from '@/src/lib/trail-maintenance/repository';
+
+interface CountyEmailDraft {
+  readonly to: string;
+  readonly subject: string;
+  readonly body: string;
+  readonly mailto: string;
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  const body = await response.text();
+  const contentType = response.headers.get('content-type') || '';
+  const isJson = contentType.includes('application/json');
+  const data: unknown = body && isJson ? JSON.parse(body) : null;
+
+  if (!response.ok) {
+    const fallback =
+      body && !body.trimStart().startsWith('<')
+        ? body.slice(0, 240)
+        : `Request failed with status ${response.status}`;
+    const message =
+      data && typeof data === 'object' && 'error' in data && typeof data.error === 'string'
+        ? data.error
+        : fallback;
+    throw new Error(message);
+  }
+
+  if (!isJson) {
+    throw new Error('Server returned a non-JSON response');
+  }
+
+  return data as T;
+}
+
+function statusColor(
+  status: TrailIssueStatus,
+): 'default' | 'info' | 'warning' | 'success' | 'error' {
+  if (status === 'resolved') return 'success';
+  if (status === 'county_needed' || status === 'county_contacted') return 'warning';
+  if (status === 'new') return 'info';
+  return 'default';
+}
+
+const trailIssueStatusShortLabels: Record<TrailIssueStatus, string> = {
+  new: 'New',
+  triaged: 'Triaged',
+  assigned: 'Assigned',
+  county_needed: 'County',
+  county_contacted: 'Contacted',
+  in_progress: 'Active',
+  resolved: 'Resolved',
+  closed_no_action: 'Closed',
+  duplicate: 'Duplicate',
+};
+
+const trailIssueStatusDefinitions: Record<TrailIssueStatus, string> = {
+  new: 'New report that has not been reviewed yet.',
+  triaged: 'Reviewed and categorized, but work has not been assigned.',
+  assigned: 'Assigned to an organizer or volunteer for follow-up.',
+  county_needed: 'Needs Onslow County Parks and Recreation help.',
+  county_contacted: 'County has been contacted and the report is waiting on follow-up.',
+  in_progress: 'Maintenance work is underway.',
+  resolved: 'Issue was addressed and the trail report is complete.',
+  closed_no_action: 'Reviewed and closed without maintenance work needed.',
+  duplicate: 'Same issue is already being tracked on another report.',
+};
+
+function mapsEmbedUrl(report: TrailMaintenanceReportDetail): string | null {
+  if (report.latitude === null || report.longitude === null) return null;
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${report.longitude - 0.002}%2C${
+    report.latitude - 0.002
+  }%2C${report.longitude + 0.002}%2C${report.latitude + 0.002}&layer=mapnik&marker=${
+    report.latitude
+  }%2C${report.longitude}`;
+}
+
+export function TrailMaintenanceManagement() {
+  const queryClient = useQueryClient();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [note, setNote] = useState('');
+  const [countyDraft, setCountyDraft] = useState<CountyEmailDraft | null>(null);
+
+  const queryParams = useMemo(() => {
+    const params = new URLSearchParams({pageSize: '50'});
+    if (statusFilter) params.set('status', statusFilter);
+    return params.toString();
+  }, [statusFilter]);
+
+  const reportsQuery = useQuery({
+    queryKey: ['admin', 'trail-maintenance', 'reports', queryParams],
+    queryFn: () =>
+      fetchJson<TrailMaintenanceListResult>(`/api/admin/trail-maintenance/reports?${queryParams}`),
+  });
+
+  const reportId = selectedId || reportsQuery.data?.reports[0]?.id || null;
+  const detailQuery = useQuery({
+    queryKey: ['admin', 'trail-maintenance', 'report', reportId],
+    queryFn: () =>
+      fetchJson<TrailMaintenanceReportDetail>(`/api/admin/trail-maintenance/reports/${reportId}`),
+    enabled: Boolean(reportId),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (input: {
+      status?: TrailIssueStatus;
+      priority?: TrailIssuePriority;
+      internalNote?: string;
+    }) =>
+      fetchJson<{ok: true}>(`/api/admin/trail-maintenance/reports/${reportId}`, {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(input),
+      }),
+    onSuccess: async () => {
+      setNote('');
+      await Promise.all([
+        queryClient.invalidateQueries({queryKey: ['admin', 'trail-maintenance', 'reports']}),
+        queryClient.invalidateQueries({
+          queryKey: ['admin', 'trail-maintenance', 'report', reportId],
+        }),
+      ]);
+    },
+  });
+
+  const countyEmailMutation = useMutation({
+    mutationFn: () =>
+      fetchJson<CountyEmailDraft>(`/api/admin/trail-maintenance/reports/${reportId}/county-email`, {
+        method: 'POST',
+      }),
+    onSuccess: (draft) => setCountyDraft(draft),
+  });
+
+  const selected = detailQuery.data;
+  const mapUrl = selected ? mapsEmbedUrl(selected) : null;
+
+  return (
+    <Box sx={{display: 'grid', gap: 3}}>
+      <Paper className="dec-card" sx={{p: 3}}>
+        <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2, alignItems: 'center'}}>
+          <Box>
+            <Typography variant="h4" component="h2">
+              Trail maintenance reports
+            </Typography>
+            <Typography color="text.secondary">
+              Review rider reports, add notes, update progress, and prepare county escalation
+              emails.
+            </Typography>
+          </Box>
+          <Button
+            variant="outlined"
+            startIcon={<RefreshIcon />}
+            onClick={() => reportsQuery.refetch()}
+            disabled={reportsQuery.isFetching}
+          >
+            Refresh
+          </Button>
+        </Box>
+      </Paper>
+
+      {(reportsQuery.error ||
+        detailQuery.error ||
+        updateMutation.error ||
+        countyEmailMutation.error) && (
+        <Alert severity="error">
+          {reportsQuery.error?.message ||
+            detailQuery.error?.message ||
+            updateMutation.error?.message ||
+            countyEmailMutation.error?.message}
+        </Alert>
+      )}
+
+      <Grid container spacing={3}>
+        <Grid size={{xs: 12, lg: 4}}>
+          <Paper className="dec-card" sx={{p: 2, display: 'grid', gap: 2}}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Status</InputLabel>
+              <Select
+                value={statusFilter}
+                label="Status"
+                onChange={(event) => setStatusFilter(event.target.value)}
+              >
+                <MenuItem value="">All open and closed</MenuItem>
+                {trailIssueStatuses.map((status) => (
+                  <MenuItem key={status} value={status}>
+                    {trailIssueStatusLabels[status]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Box sx={{display: 'grid'}}>
+              {reportsQuery.data?.reports.map((report) => (
+                <Button
+                  key={report.id}
+                  onClick={() => {
+                    setSelectedId(report.id);
+                    setCountyDraft(null);
+                  }}
+                  sx={{
+                    justifyContent: 'stretch',
+                    textAlign: 'left',
+                    p: 1.5,
+                    borderRadius: 1,
+                    bgcolor: reportId === report.id ? 'rgba(242,14,2,.08)' : 'transparent',
+                    borderBottom: '1px solid var(--dec-border)',
+                  }}
+                >
+                  <Box sx={{width: '100%', display: 'grid', gap: 0.75}}>
+                    <Box sx={{display: 'flex', gap: 1, alignItems: 'center'}}>
+                      <Typography sx={{fontWeight: 900, minWidth: 0, flex: 1}} noWrap>
+                        {report.publicId}
+                      </Typography>
+                      <Tooltip
+                        title={`${report.statusLabel}: ${trailIssueStatusDefinitions[report.status]}`}
+                        arrow
+                      >
+                        <Chip
+                          size="small"
+                          label={trailIssueStatusShortLabels[report.status]}
+                          color={statusColor(report.status)}
+                          aria-label={`Status: ${report.statusLabel}. ${
+                            trailIssueStatusDefinitions[report.status]
+                          }`}
+                          sx={{
+                            maxWidth: 96,
+                            flexShrink: 0,
+                            '& .MuiChip-label': {
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            },
+                          }}
+                        />
+                      </Tooltip>
+                    </Box>
+                    <Typography sx={{fontWeight: 800}}>{report.issueTypeLabel}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {report.trailSegmentName || report.trailSystemName}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {new Date(report.createdAt).toLocaleString()} · {report.photoCount} photo
+                      {report.photoCount === 1 ? '' : 's'}
+                    </Typography>
+                  </Box>
+                </Button>
+              ))}
+              {!reportsQuery.isLoading && reportsQuery.data?.reports.length === 0 && (
+                <Typography align="center" color="text.secondary" sx={{py: 5}}>
+                  No trail reports found.
+                </Typography>
+              )}
+            </Box>
+          </Paper>
+        </Grid>
+
+        <Grid size={{xs: 12, lg: 8}}>
+          {selected ? (
+            <Box sx={{display: 'grid', gap: 3}}>
+              <Paper className="dec-card" sx={{p: 3}}>
+                <Box sx={{display: 'flex', justifyContent: 'space-between', gap: 2, mb: 2}}>
+                  <Box>
+                    <Typography variant="h4" component="h2">
+                      {selected.issueTypeLabel}
+                    </Typography>
+                    <Typography color="text.secondary">
+                      {selected.publicId} · {selected.trailSystemName}
+                      {selected.trailSegmentName ? ` · ${selected.trailSegmentName}` : ''}
+                    </Typography>
+                  </Box>
+                  <Chip label={selected.priorityLabel} />
+                </Box>
+
+                <Grid container spacing={2}>
+                  <Grid size={{xs: 12, md: 6}}>
+                    <FormControl fullWidth size="small">
+                      <InputLabel>Status</InputLabel>
+                      <Select
+                        value={selected.status}
+                        label="Status"
+                        onChange={(event) =>
+                          updateMutation.mutate({status: event.target.value as TrailIssueStatus})
+                        }
+                      >
+                        {trailIssueStatuses.map((status) => (
+                          <MenuItem key={status} value={status}>
+                            {trailIssueStatusLabels[status]}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Grid>
+                  <Grid size={{xs: 12, md: 6}}>
+                    <FormControl fullWidth size="small">
+                      <InputLabel>Priority</InputLabel>
+                      <Select
+                        value={selected.priority}
+                        label="Priority"
+                        onChange={(event) =>
+                          updateMutation.mutate({
+                            priority: event.target.value as TrailIssuePriority,
+                          })
+                        }
+                      >
+                        {trailIssuePriorities.map((priority) => (
+                          <MenuItem key={priority} value={priority}>
+                            {trailIssuePriorityLabels[priority]}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Grid>
+                </Grid>
+
+                <Box sx={{mt: 3, display: 'grid', gap: 1}}>
+                  <Typography sx={{fontWeight: 900}}>Reporter notes</Typography>
+                  <Typography color="text.secondary">
+                    {selected.description || selected.locationNotes || 'No notes provided.'}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Observed {new Date(selected.observedAt).toLocaleString()}
+                  </Typography>
+                </Box>
+              </Paper>
+
+              <Grid container spacing={3}>
+                <Grid size={{xs: 12, md: 6}}>
+                  <Paper className="dec-card" sx={{p: 2}}>
+                    <Typography sx={{fontWeight: 900, mb: 1}}>Photos</Typography>
+                    <Box sx={{display: 'grid', gap: 1.5}}>
+                      {selected.photos.map((photo) =>
+                        photo.url ? (
+                          <Box
+                            key={photo.id}
+                            component="img"
+                            src={photo.url}
+                            alt={photo.originalFilename || 'Trail issue'}
+                            sx={{
+                              width: '100%',
+                              borderRadius: 1,
+                              border: '1px solid var(--dec-border)',
+                            }}
+                          />
+                        ) : (
+                          <Alert key={photo.id} severity="warning">
+                            R2 is not configured, so this image cannot be viewed.
+                          </Alert>
+                        ),
+                      )}
+                      {selected.photos.length === 0 && (
+                        <Typography color="text.secondary">No photos submitted.</Typography>
+                      )}
+                    </Box>
+                  </Paper>
+                </Grid>
+                <Grid size={{xs: 12, md: 6}}>
+                  <Paper className="dec-card" sx={{p: 2}}>
+                    <Typography sx={{fontWeight: 900, mb: 1}}>Location</Typography>
+                    {mapUrl ? (
+                      <Box
+                        component="iframe"
+                        title="Trail issue location"
+                        src={mapUrl}
+                        sx={{
+                          width: '100%',
+                          height: 280,
+                          border: '1px solid var(--dec-border)',
+                          borderRadius: 1,
+                        }}
+                      />
+                    ) : (
+                      <Typography color="text.secondary">
+                        {selected.locationNotes || 'No mapped location was submitted.'}
+                      </Typography>
+                    )}
+                    {selected.latitude !== null && selected.longitude !== null && (
+                      <Button
+                        href={`https://www.google.com/maps?q=${selected.latitude},${selected.longitude}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        startIcon={<MapIcon />}
+                        sx={{mt: 1}}
+                      >
+                        Open in maps
+                      </Button>
+                    )}
+                  </Paper>
+                </Grid>
+              </Grid>
+
+              <Paper className="dec-card" sx={{p: 3, display: 'grid', gap: 2}}>
+                <Typography sx={{fontWeight: 900}}>Internal notes</Typography>
+                <TextField
+                  label="Add note"
+                  multiline
+                  minRows={3}
+                  value={note}
+                  onChange={(event) => setNote(event.target.value)}
+                />
+                <Button
+                  variant="outlined"
+                  startIcon={<NoteAddIcon />}
+                  disabled={!note.trim() || updateMutation.isPending}
+                  onClick={() => updateMutation.mutate({internalNote: note})}
+                  sx={{justifySelf: 'start'}}
+                >
+                  Add note
+                </Button>
+                {selected.notes.map((item) => (
+                  <Box key={item.id} sx={{borderTop: '1px solid var(--dec-border)', pt: 1.5}}>
+                    <Typography>{item.note}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {item.authorEmail || 'Organizer'} ·{' '}
+                      {new Date(item.createdAt).toLocaleString()}
+                    </Typography>
+                  </Box>
+                ))}
+              </Paper>
+
+              <Paper className="dec-card" sx={{p: 3, display: 'grid', gap: 2}}>
+                <Typography sx={{fontWeight: 900}}>County escalation</Typography>
+                <Button
+                  variant="contained"
+                  startIcon={<EmailIcon />}
+                  disabled={countyEmailMutation.isPending}
+                  onClick={() => countyEmailMutation.mutate()}
+                  sx={{justifySelf: 'start'}}
+                >
+                  Generate county email
+                </Button>
+                {countyDraft && (
+                  <Box sx={{display: 'grid', gap: 1}}>
+                    <TextField label="To" value={countyDraft.to} size="small" />
+                    <TextField label="Subject" value={countyDraft.subject} size="small" />
+                    <TextField label="Body" value={countyDraft.body} multiline minRows={10} />
+                    <Button
+                      href={countyDraft.mailto}
+                      variant="outlined"
+                      sx={{justifySelf: 'start'}}
+                    >
+                      Open email
+                    </Button>
+                  </Box>
+                )}
+              </Paper>
+            </Box>
+          ) : (
+            <Paper className="dec-card" sx={{p: 5}}>
+              <Typography align="center" color="text.secondary">
+                Select a trail report.
+              </Typography>
+            </Paper>
+          )}
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/components/trail-maintenance/PublicTrailIssueReportForm.tsx
+++ b/src/components/trail-maintenance/PublicTrailIssueReportForm.tsx
@@ -1,0 +1,340 @@
+'use client';
+
+import AddPhotoAlternateIcon from '@mui/icons-material/AddPhotoAlternate';
+import GpsFixedIcon from '@mui/icons-material/GpsFixed';
+import ReportProblemIcon from '@mui/icons-material/ReportProblem';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import Grid from '@mui/material/Grid2';
+import {useRouter, useSearchParams} from 'next/navigation';
+import Script from 'next/script';
+import {FormEvent, useEffect, useMemo, useState} from 'react';
+
+import {
+  TRAIL_MAINTENANCE_PHOTO_LIMIT,
+  TRAIL_SYSTEM_BIG_BRANCH,
+  trailIssueTypeLabels,
+  trailIssueTypes,
+} from '@/src/lib/trail-maintenance/constants';
+import type {TrailMaintenanceOption} from '@/src/lib/trail-maintenance/repository';
+
+function localDateTimeValue(date: Date): string {
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+export function PublicTrailIssueReportForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [options, setOptions] = useState<TrailMaintenanceOption[]>([]);
+  const [trailSystemSlug, setTrailSystemSlug] = useState(
+    searchParams?.get('system') || TRAIL_SYSTEM_BIG_BRANCH,
+  );
+  const [trailSegmentSlug, setTrailSegmentSlug] = useState(searchParams?.get('trail') || '');
+  const [issueType, setIssueType] = useState('');
+  const [photoInputs, setPhotoInputs] = useState(1);
+  const [latitude, setLatitude] = useState('');
+  const [longitude, setLongitude] = useState('');
+  const [accuracy, setAccuracy] = useState('');
+  const [locationSource, setLocationSource] = useState<'manual' | 'browser_geolocation'>('manual');
+  const [locationStatus, setLocationStatus] = useState<string | null>(null);
+  const [submitStatus, setSubmitStatus] = useState<
+    {type: 'success' | 'error'; message: string} | undefined
+  >();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const selectedSystem = useMemo(
+    () => options.find((option) => option.slug === trailSystemSlug),
+    [options, trailSystemSlug],
+  );
+  const siteKey = process.env.NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY;
+
+  useEffect(() => {
+    let isMounted = true;
+    fetch('/api/trail-maintenance/options')
+      .then((response) => response.json())
+      .then((data: {trailSystems?: TrailMaintenanceOption[]}) => {
+        if (!isMounted) return;
+        const loaded = data.trailSystems ?? [];
+        setOptions(loaded);
+        const system = loaded.find((item) => item.slug === trailSystemSlug) ?? loaded[0];
+        if (system) {
+          setTrailSystemSlug(system.slug);
+          if (!trailSegmentSlug) {
+            setTrailSegmentSlug(system.segments[0]?.slug ?? '');
+          }
+        }
+      })
+      .catch(() => setSubmitStatus({type: 'error', message: 'Trail choices failed to load'}));
+    return () => {
+      isMounted = false;
+    };
+  }, [trailSegmentSlug, trailSystemSlug]);
+
+  const useCurrentLocation = () => {
+    setLocationStatus('Requesting location...');
+    if (!navigator.geolocation) {
+      setLocationStatus('Location is not available in this browser.');
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setLatitude(String(position.coords.latitude));
+        setLongitude(String(position.coords.longitude));
+        setAccuracy(String(Math.round(position.coords.accuracy)));
+        setLocationSource('browser_geolocation');
+        setLocationStatus(
+          `Location added, accuracy about ${Math.round(position.coords.accuracy)}m.`,
+        );
+      },
+      () =>
+        setLocationStatus('Location permission was not granted. Add a landmark or sign instead.'),
+      {enableHighAccuracy: true, timeout: 12_000, maximumAge: 60_000},
+    );
+  };
+
+  const submitReport = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitStatus(undefined);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    formData.set('trailSystemSlug', trailSystemSlug);
+    formData.set('trailSegmentSlug', trailSegmentSlug);
+    formData.set('issueType', issueType);
+    formData.set('locationSource', locationSource);
+    formData.set('latitude', latitude);
+    formData.set('longitude', longitude);
+    formData.set('locationAccuracyMeters', accuracy);
+
+    const turnstileToken = formData.get('cf-turnstile-response');
+    if (siteKey && (typeof turnstileToken !== 'string' || turnstileToken.length === 0)) {
+      setSubmitStatus({
+        type: 'error',
+        message:
+          'Bot check did not complete. Reload the page and try again. If you are testing locally, use the Cloudflare Turnstile test keys.',
+      });
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/trail-maintenance/reports', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'Report could not be submitted');
+      }
+      router.push(`/report-trail-issue/${encodeURIComponent(data.publicId)}`);
+    } catch (error) {
+      setSubmitStatus({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Report could not be submitted',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="md" sx={{py: {xs: 4, md: 7}}}>
+      {siteKey && (
+        <Script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer />
+      )}
+
+      <Paper className="dec-card" sx={{p: {xs: 2.5, md: 4}}}>
+        <Box sx={{display: 'flex', gap: 1.5, alignItems: 'center', mb: 2}}>
+          <ReportProblemIcon color="primary" />
+          <Typography variant="h2" sx={{fontSize: {xs: 32, md: 44}, lineHeight: 1}}>
+            Report a Big Branch Trail Issue
+          </Typography>
+        </Box>
+        <Alert severity="warning" sx={{mb: 3}}>
+          This form is not for emergencies. Call 911 for medical emergencies or immediate
+          life-safety hazards.
+        </Alert>
+
+        {submitStatus && (
+          <Alert severity={submitStatus.type} sx={{mb: 3}}>
+            {submitStatus.message}
+          </Alert>
+        )}
+
+        <Box component="form" onSubmit={submitReport} sx={{display: 'grid', gap: 3}}>
+          <Grid container spacing={2}>
+            <Grid size={{xs: 12, md: 6}}>
+              <FormControl fullWidth required>
+                <InputLabel>Issue</InputLabel>
+                <Select
+                  value={issueType}
+                  label="Issue"
+                  onChange={(event) => setIssueType(event.target.value)}
+                >
+                  {trailIssueTypes.map((type) => (
+                    <MenuItem key={type} value={type}>
+                      {trailIssueTypeLabels[type]}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid size={{xs: 12, md: 6}}>
+              <TextField
+                fullWidth
+                required
+                name="observedAt"
+                label="Observed"
+                type="datetime-local"
+                defaultValue={localDateTimeValue(new Date())}
+                slotProps={{inputLabel: {shrink: true}}}
+              />
+            </Grid>
+            {issueType === 'other' && (
+              <Grid size={{xs: 12}}>
+                <TextField fullWidth required name="issueTypeOther" label="Issue type" />
+              </Grid>
+            )}
+            <Grid size={{xs: 12, md: 6}}>
+              <FormControl fullWidth required>
+                <InputLabel>Trail system</InputLabel>
+                <Select
+                  value={trailSystemSlug}
+                  label="Trail system"
+                  onChange={(event) => {
+                    const nextSystem = options.find((option) => option.slug === event.target.value);
+                    setTrailSystemSlug(event.target.value);
+                    setTrailSegmentSlug(nextSystem?.segments[0]?.slug ?? '');
+                  }}
+                >
+                  {options.map((option) => (
+                    <MenuItem key={option.slug} value={option.slug}>
+                      {option.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid size={{xs: 12, md: 6}}>
+              <FormControl fullWidth required>
+                <InputLabel>Trail</InputLabel>
+                <Select
+                  value={trailSegmentSlug}
+                  label="Trail"
+                  onChange={(event) => setTrailSegmentSlug(event.target.value)}
+                >
+                  {(selectedSystem?.segments ?? []).map((segment) => (
+                    <MenuItem key={segment.slug} value={segment.slug}>
+                      {segment.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+          </Grid>
+
+          <Box sx={{display: 'grid', gap: 1.5}}>
+            <Button
+              type="button"
+              variant="outlined"
+              startIcon={<GpsFixedIcon />}
+              onClick={useCurrentLocation}
+              sx={{justifySelf: 'start'}}
+            >
+              Use my location
+            </Button>
+            {locationStatus && <Typography color="text.secondary">{locationStatus}</Typography>}
+            <TextField
+              name="locationNotes"
+              label="Trail sign, landmark, or location notes"
+              multiline
+              minRows={3}
+              helperText="Use current location or describe the closest sign, feature, or landmark."
+            />
+          </Box>
+
+          <TextField
+            name="description"
+            label="Details"
+            multiline
+            minRows={3}
+            helperText="Add anything that will help organizers understand the issue."
+          />
+
+          <Box sx={{display: 'grid', gap: 1}}>
+            <Typography sx={{fontWeight: 800}}>Photo of the issue</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Upload one clear photo if you can. Add more only if it helps locate or explain the
+              issue.
+            </Typography>
+            {Array.from({length: photoInputs}).map((_, index) => (
+              <Button
+                key={index}
+                component="label"
+                variant="outlined"
+                startIcon={<AddPhotoAlternateIcon />}
+                sx={{justifySelf: 'start'}}
+              >
+                {index === 0 ? 'Choose photo' : `Choose photo ${index + 1}`}
+                <input hidden name="photos" type="file" accept="image/*" />
+              </Button>
+            ))}
+            {photoInputs < TRAIL_MAINTENANCE_PHOTO_LIMIT && (
+              <Button
+                type="button"
+                variant="text"
+                onClick={() =>
+                  setPhotoInputs((count) => Math.min(count + 1, TRAIL_MAINTENANCE_PHOTO_LIMIT))
+                }
+                sx={{justifySelf: 'start'}}
+              >
+                Add another photo
+              </Button>
+            )}
+          </Box>
+
+          <Grid container spacing={2}>
+            <Grid size={{xs: 12, md: 6}}>
+              <TextField fullWidth name="reporterName" label="Name (optional)" />
+            </Grid>
+            <Grid size={{xs: 12, md: 6}}>
+              <TextField
+                fullWidth
+                name="reporterContact"
+                label="Phone or email (optional)"
+                helperText="Only used if organizers need help locating the issue."
+              />
+            </Grid>
+          </Grid>
+
+          {siteKey && <Box className="cf-turnstile" data-sitekey={siteKey} />}
+
+          <Button
+            type="submit"
+            variant="contained"
+            size="large"
+            disabled={isSubmitting || !issueType || !trailSegmentSlug}
+            startIcon={isSubmitting ? <CircularProgress size={18} /> : undefined}
+            sx={{justifySelf: 'start'}}
+          >
+            Submit report
+          </Button>
+        </Box>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -36,3 +36,52 @@ export const auditActionEnum = pgEnum('audit_action', [
   'AUTOMATED_RENEWAL_EMAIL_SENT',
   'RECONCILIATION',
 ]);
+
+export const trailIssueTypeEnum = pgEnum('trail_issue_type', [
+  'trail_obstruction',
+  'erosion_or_hole',
+  'standing_water_or_drainage',
+  'overgrown_vegetation',
+  'damaged_feature',
+  'missing_or_damaged_sign',
+  'trash_or_vandalism',
+  'other',
+]);
+
+export const trailIssueStatusEnum = pgEnum('trail_issue_status', [
+  'new',
+  'triaged',
+  'assigned',
+  'county_needed',
+  'county_contacted',
+  'in_progress',
+  'resolved',
+  'closed_no_action',
+  'duplicate',
+]);
+
+export const trailIssuePriorityEnum = pgEnum('trail_issue_priority', [
+  'low',
+  'normal',
+  'high',
+  'urgent',
+]);
+
+export const trailLocationSourceEnum = pgEnum('trail_location_source', [
+  'browser_geolocation',
+  'map_pin',
+  'manual',
+  'qr_prefill',
+]);
+
+export const trailIssueEventTypeEnum = pgEnum('trail_issue_event_type', [
+  'created',
+  'status_changed',
+  'priority_changed',
+  'assigned',
+  'note_added',
+  'county_email_generated',
+  'county_email_sent',
+  'resolved',
+  'reopened',
+]);

--- a/src/db/schema/relations.ts
+++ b/src/db/schema/relations.ts
@@ -1,12 +1,30 @@
 import {relations} from 'drizzle-orm';
 
-import {auditLog, emailLog, membershipCards, memberships, users} from './tables';
+import {
+  auditLog,
+  emailLog,
+  membershipCards,
+  memberships,
+  trailMaintenanceEvents,
+  trailMaintenanceNotes,
+  trailMaintenancePhotos,
+  trailMaintenanceReports,
+  trailSegments,
+  trailSystems,
+  users,
+} from './tables';
 
 export const usersRelations = relations(users, ({many}) => ({
   memberships: many(memberships),
   membershipCards: many(membershipCards),
   auditLogs: many(auditLog),
   emailLogs: many(emailLog),
+  assignedTrailMaintenanceReports: many(trailMaintenanceReports, {
+    relationName: 'assignedTrailMaintenanceReports',
+  }),
+  resolvedTrailMaintenanceReports: many(trailMaintenanceReports, {
+    relationName: 'resolvedTrailMaintenanceReports',
+  }),
 }));
 
 export const membershipsRelations = relations(memberships, ({one, many}) => ({
@@ -43,5 +61,74 @@ export const emailLogRelations = relations(emailLog, ({one}) => ({
   membership: one(memberships, {
     fields: [emailLog.membershipId],
     references: [memberships.id],
+  }),
+}));
+
+export const trailSystemsRelations = relations(trailSystems, ({many}) => ({
+  segments: many(trailSegments),
+  maintenanceReports: many(trailMaintenanceReports),
+}));
+
+export const trailSegmentsRelations = relations(trailSegments, ({one, many}) => ({
+  trailSystem: one(trailSystems, {
+    fields: [trailSegments.trailSystemId],
+    references: [trailSystems.id],
+  }),
+  maintenanceReports: many(trailMaintenanceReports),
+}));
+
+export const trailMaintenanceReportsRelations = relations(
+  trailMaintenanceReports,
+  ({one, many}) => ({
+    trailSystem: one(trailSystems, {
+      fields: [trailMaintenanceReports.trailSystemId],
+      references: [trailSystems.id],
+    }),
+    trailSegment: one(trailSegments, {
+      fields: [trailMaintenanceReports.trailSegmentId],
+      references: [trailSegments.id],
+    }),
+    assignedTo: one(users, {
+      fields: [trailMaintenanceReports.assignedToUserId],
+      references: [users.id],
+      relationName: 'assignedTrailMaintenanceReports',
+    }),
+    resolvedBy: one(users, {
+      fields: [trailMaintenanceReports.resolvedByUserId],
+      references: [users.id],
+      relationName: 'resolvedTrailMaintenanceReports',
+    }),
+    photos: many(trailMaintenancePhotos),
+    notes: many(trailMaintenanceNotes),
+    events: many(trailMaintenanceEvents),
+  }),
+);
+
+export const trailMaintenancePhotosRelations = relations(trailMaintenancePhotos, ({one}) => ({
+  report: one(trailMaintenanceReports, {
+    fields: [trailMaintenancePhotos.reportId],
+    references: [trailMaintenanceReports.id],
+  }),
+}));
+
+export const trailMaintenanceNotesRelations = relations(trailMaintenanceNotes, ({one}) => ({
+  report: one(trailMaintenanceReports, {
+    fields: [trailMaintenanceNotes.reportId],
+    references: [trailMaintenanceReports.id],
+  }),
+  author: one(users, {
+    fields: [trailMaintenanceNotes.authorUserId],
+    references: [users.id],
+  }),
+}));
+
+export const trailMaintenanceEventsRelations = relations(trailMaintenanceEvents, ({one}) => ({
+  report: one(trailMaintenanceReports, {
+    fields: [trailMaintenanceEvents.reportId],
+    references: [trailMaintenanceReports.id],
+  }),
+  actor: one(users, {
+    fields: [trailMaintenanceEvents.actorUserId],
+    references: [users.id],
   }),
 }));

--- a/src/db/schema/tables.ts
+++ b/src/db/schema/tables.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  doublePrecision,
   index,
   integer,
   jsonb,
@@ -18,6 +19,11 @@ import {
   membershipStatusEnum,
   planIntervalEnum,
   planTypeEnum,
+  trailIssueEventTypeEnum,
+  trailIssuePriorityEnum,
+  trailIssueStatusEnum,
+  trailIssueTypeEnum,
+  trailLocationSourceEnum,
   webhookStatusEnum,
 } from './enums';
 
@@ -251,4 +257,157 @@ export const meetupEvents = pgTable(
     lastSeenAt: timestamp('last_seen_at', {withTimezone: true}).defaultNow().notNull(),
   },
   (table) => [index('meetup_events_start_date_idx').on(table.startDate)],
+);
+
+// ---------------------------------------------------------------------------
+// 11. Trail Maintenance
+// ---------------------------------------------------------------------------
+
+export const trailSystems = pgTable(
+  'trail_systems',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    slug: varchar('slug', {length: 80}).notNull().unique(),
+    name: varchar('name', {length: 160}).notNull(),
+    description: text('description'),
+    isActive: boolean('is_active').notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', {withTimezone: true}).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('trail_systems_slug_idx').on(table.slug),
+    index('trail_systems_active_sort_idx').on(table.isActive, table.sortOrder),
+  ],
+);
+
+export const trailSegments = pgTable(
+  'trail_segments',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    trailSystemId: uuid('trail_system_id')
+      .notNull()
+      .references(() => trailSystems.id, {onDelete: 'cascade'}),
+    slug: varchar('slug', {length: 80}).notNull(),
+    name: varchar('name', {length: 160}).notNull(),
+    colorLabel: varchar('color_label', {length: 80}),
+    isActive: boolean('is_active').notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', {withTimezone: true}).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('trail_segments_system_slug_idx').on(table.trailSystemId, table.slug),
+    index('trail_segments_system_active_sort_idx').on(
+      table.trailSystemId,
+      table.isActive,
+      table.sortOrder,
+    ),
+  ],
+);
+
+export const trailMaintenanceReports = pgTable(
+  'trail_maintenance_reports',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    publicId: varchar('public_id', {length: 24}).notNull().unique(),
+    trailSystemId: uuid('trail_system_id')
+      .notNull()
+      .references(() => trailSystems.id, {onDelete: 'restrict'}),
+    trailSegmentId: uuid('trail_segment_id').references(() => trailSegments.id, {
+      onDelete: 'set null',
+    }),
+    issueType: trailIssueTypeEnum('issue_type').notNull(),
+    issueTypeOther: varchar('issue_type_other', {length: 160}),
+    status: trailIssueStatusEnum('status').notNull().default('new'),
+    priority: trailIssuePriorityEnum('priority').notNull().default('normal'),
+    observedAt: timestamp('observed_at', {withTimezone: true}).notNull(),
+    description: text('description'),
+    locationSource: trailLocationSourceEnum('location_source').notNull().default('manual'),
+    locationNotes: text('location_notes'),
+    latitude: doublePrecision('latitude'),
+    longitude: doublePrecision('longitude'),
+    locationAccuracyMeters: doublePrecision('location_accuracy_meters'),
+    reporterName: varchar('reporter_name', {length: 160}),
+    reporterContact: varchar('reporter_contact', {length: 255}),
+    userAgent: text('user_agent'),
+    submitterIpHash: varchar('submitter_ip_hash', {length: 128}),
+    assignedToUserId: uuid('assigned_to_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    countyEmailGeneratedAt: timestamp('county_email_generated_at', {withTimezone: true}),
+    countyEmailSentAt: timestamp('county_email_sent_at', {withTimezone: true}),
+    resolvedByUserId: uuid('resolved_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    resolvedAt: timestamp('resolved_at', {withTimezone: true}),
+    createdAt: timestamp('created_at', {withTimezone: true}).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('trail_maintenance_reports_public_id_idx').on(table.publicId),
+    index('trail_maintenance_reports_status_idx').on(table.status),
+    index('trail_maintenance_reports_priority_idx').on(table.priority),
+    index('trail_maintenance_reports_created_at_idx').on(table.createdAt),
+    index('trail_maintenance_reports_system_status_idx').on(table.trailSystemId, table.status),
+  ],
+);
+
+export const trailMaintenancePhotos = pgTable(
+  'trail_maintenance_photos',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    reportId: uuid('report_id')
+      .notNull()
+      .references(() => trailMaintenanceReports.id, {onDelete: 'cascade'}),
+    bucketName: varchar('bucket_name', {length: 160}).notNull(),
+    objectKey: text('object_key').notNull(),
+    originalFilename: varchar('original_filename', {length: 255}),
+    contentType: varchar('content_type', {length: 120}).notNull(),
+    byteSize: integer('byte_size').notNull(),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', {withTimezone: true}).defaultNow().notNull(),
+  },
+  (table) => [
+    index('trail_maintenance_photos_report_idx').on(table.reportId),
+    uniqueIndex('trail_maintenance_photos_object_key_idx').on(table.objectKey),
+  ],
+);
+
+export const trailMaintenanceNotes = pgTable(
+  'trail_maintenance_notes',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    reportId: uuid('report_id')
+      .notNull()
+      .references(() => trailMaintenanceReports.id, {onDelete: 'cascade'}),
+    authorUserId: uuid('author_user_id').references(() => users.id, {onDelete: 'set null'}),
+    authorEmail: varchar('author_email', {length: 255}),
+    note: text('note').notNull(),
+    isPublic: boolean('is_public').notNull().default(false),
+    createdAt: timestamp('created_at', {withTimezone: true}).defaultNow().notNull(),
+  },
+  (table) => [
+    index('trail_maintenance_notes_report_idx').on(table.reportId),
+    index('trail_maintenance_notes_created_at_idx').on(table.createdAt),
+  ],
+);
+
+export const trailMaintenanceEvents = pgTable(
+  'trail_maintenance_events',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    reportId: uuid('report_id')
+      .notNull()
+      .references(() => trailMaintenanceReports.id, {onDelete: 'cascade'}),
+    eventType: trailIssueEventTypeEnum('event_type').notNull(),
+    actorUserId: uuid('actor_user_id').references(() => users.id, {onDelete: 'set null'}),
+    actorLabel: varchar('actor_label', {length: 255}).notNull(),
+    details: jsonb('details').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', {withTimezone: true}).defaultNow().notNull(),
+  },
+  (table) => [
+    index('trail_maintenance_events_report_idx').on(table.reportId),
+    index('trail_maintenance_events_created_at_idx').on(table.createdAt),
+  ],
 );

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -23,6 +23,7 @@ export type DashboardCapability =
   | 'stats:read'
   | 'stats:refresh'
   | 'trails:update'
+  | 'trail-maintenance:manage'
   | 'reconciliation:run'
   | 'organizers:manage';
 
@@ -36,6 +37,7 @@ const organizerCapabilities: ReadonlySet<DashboardCapability> = new Set([
   'stats:read',
   'stats:refresh',
   'trails:update',
+  'trail-maintenance:manage',
 ]);
 
 const adminCapabilities: ReadonlySet<DashboardCapability> = new Set([

--- a/src/lib/api/admin-route-handler.ts
+++ b/src/lib/api/admin-route-handler.ts
@@ -34,6 +34,14 @@ type ErrorResult = {
   status: number;
 };
 
+function messageFromUnknown(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return 'An unexpected error occurred';
+}
+
 /**
  * Common error handlers for admin routes
  */
@@ -143,7 +151,13 @@ export async function handleAdminRoute(options: AdminRouteOptions): Promise<Next
     }),
   );
 
-  const result = await Effect.runPromise(program.pipe(Effect.provide(LiveLayer)));
+  let result: unknown;
+  try {
+    result = await Effect.runPromise(program.pipe(Effect.provide(LiveLayer)));
+  } catch (error) {
+    console.error('Unhandled admin route failure:', error);
+    return NextResponse.json({error: messageFromUnknown(error)}, {status: 500});
+  }
 
   if (
     typeof result === 'object' &&

--- a/src/lib/trail-maintenance/constants.ts
+++ b/src/lib/trail-maintenance/constants.ts
@@ -1,0 +1,91 @@
+export const TRAIL_SYSTEM_BIG_BRANCH = 'big-branch-bike-park';
+
+export const TRAIL_MAINTENANCE_PHOTO_LIMIT = 3;
+export const TRAIL_MAINTENANCE_PHOTO_MAX_BYTES = 10 * 1024 * 1024;
+
+export const trailIssueTypes = [
+  'trail_obstruction',
+  'erosion_or_hole',
+  'standing_water_or_drainage',
+  'overgrown_vegetation',
+  'damaged_feature',
+  'missing_or_damaged_sign',
+  'trash_or_vandalism',
+  'other',
+] as const;
+
+export const trailIssueStatuses = [
+  'new',
+  'triaged',
+  'assigned',
+  'county_needed',
+  'county_contacted',
+  'in_progress',
+  'resolved',
+  'closed_no_action',
+  'duplicate',
+] as const;
+
+export const trailIssuePriorities = ['low', 'normal', 'high', 'urgent'] as const;
+
+export const trailLocationSources = [
+  'browser_geolocation',
+  'map_pin',
+  'manual',
+  'qr_prefill',
+] as const;
+
+export type TrailIssueType = (typeof trailIssueTypes)[number];
+export type TrailIssueStatus = (typeof trailIssueStatuses)[number];
+export type TrailIssuePriority = (typeof trailIssuePriorities)[number];
+export type TrailLocationSource = (typeof trailLocationSources)[number];
+
+export const trailIssueTypeLabels: Record<TrailIssueType, string> = {
+  trail_obstruction: 'Trail obstruction',
+  erosion_or_hole: 'Erosion or hole',
+  standing_water_or_drainage: 'Standing water or poor drainage',
+  overgrown_vegetation: 'Overgrown vegetation',
+  damaged_feature: 'Damaged feature',
+  missing_or_damaged_sign: 'Missing or damaged sign',
+  trash_or_vandalism: 'Trash or vandalism',
+  other: 'Other',
+};
+
+export const trailIssueStatusLabels: Record<TrailIssueStatus, string> = {
+  new: 'New',
+  triaged: 'Triaged',
+  assigned: 'Assigned',
+  county_needed: 'County needed',
+  county_contacted: 'County contacted',
+  in_progress: 'In progress',
+  resolved: 'Resolved',
+  closed_no_action: 'Closed - no action',
+  duplicate: 'Duplicate',
+};
+
+export const trailIssuePriorityLabels: Record<TrailIssuePriority, string> = {
+  low: 'Low',
+  normal: 'Normal',
+  high: 'High',
+  urgent: 'Urgent',
+};
+
+export const defaultTrailSystems = [
+  {
+    slug: TRAIL_SYSTEM_BIG_BRANCH,
+    name: 'Big Branch Bike Park',
+    segments: [
+      {slug: 'phase-1-green-ricochet', name: 'Phase 1 Green (Ricochet)', colorLabel: 'Green'},
+      {
+        slug: 'phase-1-blue-ridge-runners-loop',
+        name: 'Phase 1 Blue (Ridge Runners Loop)',
+        colorLabel: 'Blue',
+      },
+      {
+        slug: 'phase-2-blue-trail-dynamic',
+        name: 'Phase 2 Blue (Trail Dynamic)',
+        colorLabel: 'Blue',
+      },
+    ],
+  },
+] as const;

--- a/src/lib/trail-maintenance/notifications.ts
+++ b/src/lib/trail-maintenance/notifications.ts
@@ -1,0 +1,75 @@
+import {Resend} from 'resend';
+
+import {getSiteUrl} from '@/src/lib/site-url';
+
+import type {TrailMaintenanceReportDetail} from './repository';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export async function sendTrailMaintenanceNotification({
+  report,
+  recipients,
+}: {
+  readonly report: TrailMaintenanceReportDetail;
+  readonly recipients: readonly string[];
+}): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey || recipients.length === 0) {
+    console.warn('[TrailMaintenance] Skipping notification: Resend or recipients missing');
+    return;
+  }
+
+  const resend = new Resend(apiKey);
+  const from = process.env.EMAIL_FROM ?? 'Down East Cyclists <noreply@downeastcyclists.com>';
+  const dashboardUrl = `${getSiteUrl()}/dashboard`;
+  const subject = `New trail report ${report.publicId}: ${report.issueTypeLabel}`;
+  const location =
+    report.latitude && report.longitude
+      ? `${report.latitude.toFixed(6)}, ${report.longitude.toFixed(6)}`
+      : report.locationNotes || 'Location notes unavailable';
+
+  const text = [
+    `New trail maintenance report ${report.publicId}`,
+    '',
+    `Issue: ${report.issueTypeLabel}`,
+    `Trail: ${report.trailSystemName}${report.trailSegmentName ? ` - ${report.trailSegmentName}` : ''}`,
+    `Location: ${location}`,
+    `Photos: ${report.photoCount}`,
+    '',
+    'Open the organizer dashboard:',
+    dashboardUrl,
+  ].join('\n');
+
+  const html = `
+    <p>New trail maintenance report <strong>${escapeHtml(report.publicId)}</strong></p>
+    <p><strong>Issue:</strong> ${escapeHtml(report.issueTypeLabel)}</p>
+    <p><strong>Trail:</strong> ${escapeHtml(report.trailSystemName)}${
+      report.trailSegmentName ? ` - ${escapeHtml(report.trailSegmentName)}` : ''
+    }</p>
+    <p><strong>Location:</strong> ${escapeHtml(location)}</p>
+    <p><strong>Photos:</strong> ${report.photoCount}</p>
+    <p><a href="${escapeHtml(dashboardUrl)}">Open organizer dashboard</a></p>
+  `.trim();
+
+  const {error} = await resend.emails.send(
+    {
+      from,
+      to: [...recipients],
+      subject,
+      html,
+      text,
+    },
+    {idempotencyKey: `trail-maintenance/${report.publicId}`},
+  );
+
+  if (error) {
+    console.error('[TrailMaintenance] Failed to send notification:', error);
+  }
+}

--- a/src/lib/trail-maintenance/r2.ts
+++ b/src/lib/trail-maintenance/r2.ts
@@ -1,0 +1,293 @@
+import {createHash, createHmac} from 'crypto';
+
+import {TRAIL_MAINTENANCE_PHOTO_MAX_BYTES, TRAIL_MAINTENANCE_PHOTO_LIMIT} from './constants';
+
+export interface StoredTrailPhoto {
+  readonly bucketName: string;
+  readonly objectKey: string;
+  readonly originalFilename: string;
+  readonly contentType: string;
+  readonly byteSize: number;
+  readonly sortOrder: number;
+}
+
+interface R2Config {
+  readonly accountId: string;
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly bucketName: string;
+}
+
+const R2_REGION = 'auto';
+const R2_SERVICE = 's3';
+
+function getR2Config(): R2Config | null {
+  const accountId = process.env.R2_ACCOUNT_ID;
+  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+  const bucketName = process.env.R2_BUCKET_NAME;
+
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
+    return null;
+  }
+
+  return {
+    accountId,
+    accessKeyId,
+    secretAccessKey,
+    bucketName,
+  };
+}
+
+function hash(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmac(key: string | Buffer, value: string): Buffer {
+  return createHmac('sha256', key).update(value).digest();
+}
+
+function formatAmzDate(date: Date): {readonly dateStamp: string; readonly amzDate: string} {
+  const iso = date.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  return {
+    dateStamp: iso.slice(0, 8),
+    amzDate: iso,
+  };
+}
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function canonicalUri(bucketName: string, objectKey: string): string {
+  return `/${encodePathSegment(bucketName)}/${objectKey
+    .split('/')
+    .map(encodePathSegment)
+    .join('/')}`;
+}
+
+function canonicalQuery(params: ReadonlyMap<string, string>): string {
+  return [...params.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${encodePathSegment(key)}=${encodePathSegment(value)}`)
+    .join('&');
+}
+
+function signingKey(secretAccessKey: string, dateStamp: string): Buffer {
+  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const regionKey = hmac(dateKey, R2_REGION);
+  const serviceKey = hmac(regionKey, R2_SERVICE);
+  return hmac(serviceKey, 'aws4_request');
+}
+
+function signature({
+  secretAccessKey,
+  dateStamp,
+  amzDate,
+  canonicalRequest,
+}: {
+  readonly secretAccessKey: string;
+  readonly dateStamp: string;
+  readonly amzDate: string;
+  readonly canonicalRequest: string;
+}): string {
+  const credentialScope = `${dateStamp}/${R2_REGION}/${R2_SERVICE}/aws4_request`;
+  const stringToSign = ['AWS4-HMAC-SHA256', amzDate, credentialScope, hash(canonicalRequest)].join(
+    '\n',
+  );
+
+  return createHmac('sha256', signingKey(secretAccessKey, dateStamp))
+    .update(stringToSign)
+    .digest('hex');
+}
+
+function r2Endpoint(config: R2Config, objectKey: string): URL {
+  return new URL(
+    `https://${config.accountId}.r2.cloudflarestorage.com${canonicalUri(
+      config.bucketName,
+      objectKey,
+    )}`,
+  );
+}
+
+function putObjectHeaders({
+  config,
+  objectKey,
+  contentType,
+  payloadHash,
+}: {
+  readonly config: R2Config;
+  readonly objectKey: string;
+  readonly contentType: string;
+  readonly payloadHash: string;
+}): Headers {
+  const {dateStamp, amzDate} = formatAmzDate(new Date());
+  const host = `${config.accountId}.r2.cloudflarestorage.com`;
+  const signedHeaders = 'content-type;host;x-amz-content-sha256;x-amz-date';
+  const canonicalRequest = [
+    'PUT',
+    canonicalUri(config.bucketName, objectKey),
+    '',
+    `content-type:${contentType}`,
+    `host:${host}`,
+    `x-amz-content-sha256:${payloadHash}`,
+    `x-amz-date:${amzDate}`,
+    '',
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+  const credentialScope = `${dateStamp}/${R2_REGION}/${R2_SERVICE}/aws4_request`;
+  const authorization = `AWS4-HMAC-SHA256 ${[
+    `Credential=${config.accessKeyId}/${credentialScope}`,
+    `SignedHeaders=${signedHeaders}`,
+    `Signature=${signature({
+      secretAccessKey: config.secretAccessKey,
+      dateStamp,
+      amzDate,
+      canonicalRequest,
+    })}`,
+  ].join(', ')}`;
+
+  return new Headers({
+    Authorization: authorization,
+    'Content-Type': contentType,
+    'X-Amz-Content-Sha256': payloadHash,
+    'X-Amz-Date': amzDate,
+  });
+}
+
+async function putObject({
+  config,
+  objectKey,
+  body,
+  contentType,
+}: {
+  readonly config: R2Config;
+  readonly objectKey: string;
+  readonly body: ArrayBuffer;
+  readonly contentType: string;
+}): Promise<void> {
+  const payloadHash = hash(Buffer.from(body));
+  const response = await fetch(r2Endpoint(config, objectKey), {
+    method: 'PUT',
+    headers: putObjectHeaders({config, objectKey, contentType, payloadHash}),
+    body,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Cloudflare R2 upload failed with status ${response.status}${
+        body ? `: ${body.slice(0, 500)}` : ''
+      }`,
+    );
+  }
+}
+
+export function isAllowedTrailPhoto(file: File): boolean {
+  return (
+    file.type.startsWith('image/') &&
+    file.size > 0 &&
+    file.size <= TRAIL_MAINTENANCE_PHOTO_MAX_BYTES
+  );
+}
+
+export async function storeTrailMaintenancePhotos({
+  publicId,
+  files,
+}: {
+  readonly publicId: string;
+  readonly files: readonly File[];
+}): Promise<StoredTrailPhoto[]> {
+  if (files.length === 0) return [];
+
+  const config = getR2Config();
+  if (!config) {
+    throw new Error('Cloudflare R2 is not configured');
+  }
+
+  if (files.length > TRAIL_MAINTENANCE_PHOTO_LIMIT) {
+    throw new Error(`Upload up to ${TRAIL_MAINTENANCE_PHOTO_LIMIT} photos`);
+  }
+
+  const uploads: StoredTrailPhoto[] = [];
+  for (const [index, file] of files.entries()) {
+    if (!isAllowedTrailPhoto(file)) {
+      throw new Error('Photos must be image files no larger than 10 MB');
+    }
+
+    const extension =
+      file.name
+        .split('.')
+        .pop()
+        ?.toLowerCase()
+        .replace(/[^a-z0-9]/g, '') || 'jpg';
+    const objectKey = `trail-maintenance/${publicId}/${index + 1}.${extension}`;
+    const body = await file.arrayBuffer();
+
+    await putObject({
+      config,
+      objectKey,
+      body,
+      contentType: file.type,
+    });
+
+    uploads.push({
+      bucketName: config.bucketName,
+      objectKey,
+      originalFilename: file.name,
+      contentType: file.type,
+      byteSize: file.size,
+      sortOrder: index,
+    });
+  }
+
+  return uploads;
+}
+
+export async function getTrailPhotoSignedUrl({
+  bucketName,
+  objectKey,
+}: {
+  readonly bucketName: string;
+  readonly objectKey: string;
+}): Promise<string | null> {
+  const config = getR2Config();
+  if (!config || bucketName !== config.bucketName) return null;
+
+  const {dateStamp, amzDate} = formatAmzDate(new Date());
+  const credentialScope = `${dateStamp}/${R2_REGION}/${R2_SERVICE}/aws4_request`;
+  const params = new Map([
+    ['X-Amz-Algorithm', 'AWS4-HMAC-SHA256'],
+    ['X-Amz-Credential', `${config.accessKeyId}/${credentialScope}`],
+    ['X-Amz-Date', amzDate],
+    ['X-Amz-Expires', String(15 * 60)],
+    ['X-Amz-SignedHeaders', 'host'],
+  ]);
+  const host = `${config.accountId}.r2.cloudflarestorage.com`;
+  const canonicalRequest = [
+    'GET',
+    canonicalUri(config.bucketName, objectKey),
+    canonicalQuery(params),
+    `host:${host}`,
+    '',
+    'host',
+    'UNSIGNED-PAYLOAD',
+  ].join('\n');
+  params.set(
+    'X-Amz-Signature',
+    signature({
+      secretAccessKey: config.secretAccessKey,
+      dateStamp,
+      amzDate,
+      canonicalRequest,
+    }),
+  );
+
+  const url = r2Endpoint(config, objectKey);
+  url.search = canonicalQuery(params);
+  return url.toString();
+}

--- a/src/lib/trail-maintenance/repository.ts
+++ b/src/lib/trail-maintenance/repository.ts
@@ -1,0 +1,596 @@
+import {createHash, randomUUID} from 'node:crypto';
+
+import {and, asc, count, desc, eq, sql} from 'drizzle-orm';
+
+import {db} from '@/src/db/client';
+import {
+  trailMaintenanceEvents,
+  trailMaintenanceNotes,
+  trailMaintenancePhotos,
+  trailMaintenanceReports,
+  trailSegments,
+  trailSystems,
+  users,
+} from '@/src/db/schema/tables';
+
+import {
+  trailIssuePriorityLabels,
+  trailIssueStatusLabels,
+  trailIssueTypeLabels,
+  type TrailIssuePriority,
+  type TrailIssueStatus,
+} from './constants';
+import {getTrailPhotoSignedUrl, type StoredTrailPhoto} from './r2';
+import type {
+  PublicTrailMaintenanceReportInput,
+  TrailMaintenanceListQuery,
+  TrailMaintenanceUpdateInput,
+} from './validation';
+
+export interface TrailMaintenanceOption {
+  readonly slug: string;
+  readonly name: string;
+  readonly segments: ReadonlyArray<{
+    readonly slug: string;
+    readonly name: string;
+    readonly colorLabel: string | null;
+  }>;
+}
+
+export interface TrailMaintenanceReportSummary {
+  readonly id: string;
+  readonly publicId: string;
+  readonly issueType: string;
+  readonly issueTypeLabel: string;
+  readonly status: TrailIssueStatus;
+  readonly statusLabel: string;
+  readonly priority: TrailIssuePriority;
+  readonly priorityLabel: string;
+  readonly trailSystemName: string;
+  readonly trailSegmentName: string | null;
+  readonly observedAt: string;
+  readonly createdAt: string;
+  readonly photoCount: number;
+  readonly latitude: number | null;
+  readonly longitude: number | null;
+  readonly locationNotes: string | null;
+}
+
+export interface TrailMaintenanceReportDetail extends TrailMaintenanceReportSummary {
+  readonly description: string | null;
+  readonly reporterName: string | null;
+  readonly reporterContact: string | null;
+  readonly photos: ReadonlyArray<{
+    readonly id: string;
+    readonly url: string | null;
+    readonly originalFilename: string | null;
+    readonly contentType: string;
+    readonly byteSize: number;
+  }>;
+  readonly notes: ReadonlyArray<{
+    readonly id: string;
+    readonly note: string;
+    readonly authorEmail: string | null;
+    readonly createdAt: string;
+  }>;
+  readonly events: ReadonlyArray<{
+    readonly id: string;
+    readonly eventType: string;
+    readonly actorLabel: string;
+    readonly details: Record<string, unknown> | null;
+    readonly createdAt: string;
+  }>;
+}
+
+export interface PublicTrailMaintenanceReportDetail {
+  readonly publicId: string;
+  readonly issueTypeLabel: string;
+  readonly status: TrailIssueStatus;
+  readonly statusLabel: string;
+  readonly priority: TrailIssuePriority;
+  readonly priorityLabel: string;
+  readonly trailSystemName: string;
+  readonly trailSegmentName: string | null;
+  readonly observedAt: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly resolvedAt: string | null;
+  readonly latitude: number | null;
+  readonly longitude: number | null;
+  readonly locationNotes: string | null;
+  readonly description: string | null;
+  readonly photos: ReadonlyArray<{
+    readonly id: string;
+    readonly url: string | null;
+    readonly originalFilename: string | null;
+    readonly contentType: string;
+    readonly byteSize: number;
+  }>;
+}
+
+export interface TrailMaintenanceListResult {
+  readonly reports: TrailMaintenanceReportSummary[];
+  readonly total: number;
+}
+
+export interface StaffActor {
+  readonly uid: string;
+  readonly email?: string;
+}
+
+function makePublicId(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 12).toUpperCase();
+}
+
+function hashIp(ip: string | null): string | null {
+  if (!ip) return null;
+  return createHash('sha256')
+    .update(`${process.env.QR_SIGNING_SECRET ?? 'trail-maintenance'}:${ip}`)
+    .digest('hex');
+}
+
+function issueTypeLabel(issueType: string, issueTypeOther: string | null): string {
+  if (issueType === 'other' && issueTypeOther) return issueTypeOther;
+  return trailIssueTypeLabels[issueType as keyof typeof trailIssueTypeLabels] ?? issueType;
+}
+
+function actorLabel(actor: StaffActor): string {
+  return actor.email || actor.uid;
+}
+
+async function resolveStaffUser(actor: StaffActor) {
+  return db
+    .select()
+    .from(users)
+    .where(eq(users.firebaseUid, actor.uid))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}
+
+export async function getTrailMaintenanceOptions(): Promise<TrailMaintenanceOption[]> {
+  const systems = await db
+    .select()
+    .from(trailSystems)
+    .where(eq(trailSystems.isActive, true))
+    .orderBy(asc(trailSystems.sortOrder), asc(trailSystems.name));
+
+  const segments = await db
+    .select()
+    .from(trailSegments)
+    .where(eq(trailSegments.isActive, true))
+    .orderBy(asc(trailSegments.sortOrder), asc(trailSegments.name));
+
+  return systems.map((system) => ({
+    slug: system.slug,
+    name: system.name,
+    segments: segments
+      .filter((segment) => segment.trailSystemId === system.id)
+      .map((segment) => ({
+        slug: segment.slug,
+        name: segment.name,
+        colorLabel: segment.colorLabel,
+      })),
+  }));
+}
+
+export async function createTrailMaintenanceReport({
+  input,
+  photos,
+  publicId = makePublicId(),
+  userAgent,
+  remoteIp,
+}: {
+  readonly input: PublicTrailMaintenanceReportInput;
+  readonly photos: readonly StoredTrailPhoto[];
+  readonly publicId?: string;
+  readonly userAgent: string | null;
+  readonly remoteIp: string | null;
+}): Promise<{readonly id: string; readonly publicId: string}> {
+  const [system] = await db
+    .select()
+    .from(trailSystems)
+    .where(eq(trailSystems.slug, input.trailSystemSlug))
+    .limit(1);
+  if (!system) {
+    throw new Error('Trail system not found');
+  }
+
+  const [segment] = await db
+    .select()
+    .from(trailSegments)
+    .where(
+      and(
+        eq(trailSegments.trailSystemId, system.id),
+        eq(trailSegments.slug, input.trailSegmentSlug),
+      ),
+    )
+    .limit(1);
+  if (!segment) {
+    throw new Error('Trail not found');
+  }
+
+  const [report] = await db
+    .insert(trailMaintenanceReports)
+    .values({
+      publicId,
+      trailSystemId: system.id,
+      trailSegmentId: segment.id,
+      issueType: input.issueType,
+      issueTypeOther: input.issueTypeOther ?? null,
+      observedAt: input.observedAt,
+      description: input.description ?? null,
+      locationSource: input.locationSource,
+      locationNotes: input.locationNotes ?? null,
+      latitude: input.latitude ?? null,
+      longitude: input.longitude ?? null,
+      locationAccuracyMeters: input.locationAccuracyMeters ?? null,
+      reporterName: input.reporterName ?? null,
+      reporterContact: input.reporterContact ?? null,
+      userAgent,
+      submitterIpHash: hashIp(remoteIp),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning();
+
+  if (photos.length > 0) {
+    await db.insert(trailMaintenancePhotos).values(
+      photos.map((photo) => ({
+        reportId: report.id,
+        bucketName: photo.bucketName,
+        objectKey: photo.objectKey,
+        originalFilename: photo.originalFilename,
+        contentType: photo.contentType,
+        byteSize: photo.byteSize,
+        sortOrder: photo.sortOrder,
+        createdAt: new Date(),
+      })),
+    );
+  }
+
+  await db.insert(trailMaintenanceEvents).values({
+    reportId: report.id,
+    eventType: 'created',
+    actorLabel: 'Public reporter',
+    details: {photoCount: photos.length},
+    createdAt: new Date(),
+  });
+
+  return {id: report.id, publicId};
+}
+
+export async function getTrailMaintenanceReportRecipients(): Promise<string[]> {
+  const organizerRows = await db
+    .select({email: users.email})
+    .from(users)
+    .where(eq(users.isOrganizer, true));
+
+  const adminEmails = [
+    process.env.ADMIN_EMAIL,
+    ...(process.env.ADMIN_EMAIL_WHITELIST ?? '').split(','),
+  ];
+
+  return Array.from(
+    new Set(
+      [...organizerRows.map((row) => row.email), ...adminEmails]
+        .map((email) => email?.trim())
+        .filter((email): email is string => Boolean(email)),
+    ),
+  );
+}
+
+export async function listTrailMaintenanceReports(
+  query: TrailMaintenanceListQuery,
+): Promise<TrailMaintenanceListResult> {
+  const conditions = [
+    query.status ? eq(trailMaintenanceReports.status, query.status) : undefined,
+    query.priority ? eq(trailMaintenanceReports.priority, query.priority) : undefined,
+    query.issueType ? eq(trailMaintenanceReports.issueType, query.issueType) : undefined,
+  ].filter((condition) => condition !== undefined);
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+  const offset = (query.page - 1) * query.pageSize;
+
+  const totalRows = await db.select({count: count()}).from(trailMaintenanceReports).where(where);
+
+  const rows = await db
+    .select({
+      report: trailMaintenanceReports,
+      systemName: trailSystems.name,
+      segmentName: trailSegments.name,
+      photoCount: sql<number>`count(${trailMaintenancePhotos.id})::int`,
+    })
+    .from(trailMaintenanceReports)
+    .innerJoin(trailSystems, eq(trailMaintenanceReports.trailSystemId, trailSystems.id))
+    .leftJoin(trailSegments, eq(trailMaintenanceReports.trailSegmentId, trailSegments.id))
+    .leftJoin(
+      trailMaintenancePhotos,
+      eq(trailMaintenanceReports.id, trailMaintenancePhotos.reportId),
+    )
+    .where(where)
+    .groupBy(trailMaintenanceReports.id, trailSystems.name, trailSegments.name)
+    .orderBy(desc(trailMaintenanceReports.createdAt))
+    .limit(query.pageSize)
+    .offset(offset);
+
+  return {
+    total: totalRows[0]?.count ?? 0,
+    reports: rows.map((row) => ({
+      id: row.report.id,
+      publicId: row.report.publicId,
+      issueType: row.report.issueType,
+      issueTypeLabel: issueTypeLabel(row.report.issueType, row.report.issueTypeOther),
+      status: row.report.status,
+      statusLabel: trailIssueStatusLabels[row.report.status],
+      priority: row.report.priority,
+      priorityLabel: trailIssuePriorityLabels[row.report.priority],
+      trailSystemName: row.systemName,
+      trailSegmentName: row.segmentName,
+      observedAt: row.report.observedAt.toISOString(),
+      createdAt: row.report.createdAt.toISOString(),
+      photoCount: row.photoCount,
+      latitude: row.report.latitude,
+      longitude: row.report.longitude,
+      locationNotes: row.report.locationNotes,
+    })),
+  };
+}
+
+export async function getTrailMaintenanceReportDetail(
+  reportId: string,
+): Promise<TrailMaintenanceReportDetail | null> {
+  const [row] = await db
+    .select({
+      report: trailMaintenanceReports,
+      systemName: trailSystems.name,
+      segmentName: trailSegments.name,
+      photoCount: sql<number>`count(${trailMaintenancePhotos.id})::int`,
+    })
+    .from(trailMaintenanceReports)
+    .innerJoin(trailSystems, eq(trailMaintenanceReports.trailSystemId, trailSystems.id))
+    .leftJoin(trailSegments, eq(trailMaintenanceReports.trailSegmentId, trailSegments.id))
+    .leftJoin(
+      trailMaintenancePhotos,
+      eq(trailMaintenanceReports.id, trailMaintenancePhotos.reportId),
+    )
+    .where(eq(trailMaintenanceReports.id, reportId))
+    .groupBy(trailMaintenanceReports.id, trailSystems.name, trailSegments.name)
+    .limit(1);
+
+  if (!row) return null;
+
+  const [photoRows, noteRows, eventRows] = await Promise.all([
+    db
+      .select()
+      .from(trailMaintenancePhotos)
+      .where(eq(trailMaintenancePhotos.reportId, reportId))
+      .orderBy(asc(trailMaintenancePhotos.sortOrder), asc(trailMaintenancePhotos.createdAt)),
+    db
+      .select()
+      .from(trailMaintenanceNotes)
+      .where(eq(trailMaintenanceNotes.reportId, reportId))
+      .orderBy(desc(trailMaintenanceNotes.createdAt)),
+    db
+      .select()
+      .from(trailMaintenanceEvents)
+      .where(eq(trailMaintenanceEvents.reportId, reportId))
+      .orderBy(desc(trailMaintenanceEvents.createdAt)),
+  ]);
+
+  const photos = await Promise.all(
+    photoRows.map(async (photo) => ({
+      id: photo.id,
+      url: await getTrailPhotoSignedUrl({
+        bucketName: photo.bucketName,
+        objectKey: photo.objectKey,
+      }),
+      originalFilename: photo.originalFilename,
+      contentType: photo.contentType,
+      byteSize: photo.byteSize,
+    })),
+  );
+
+  return {
+    id: row.report.id,
+    publicId: row.report.publicId,
+    issueType: row.report.issueType,
+    issueTypeLabel: issueTypeLabel(row.report.issueType, row.report.issueTypeOther),
+    status: row.report.status,
+    statusLabel: trailIssueStatusLabels[row.report.status],
+    priority: row.report.priority,
+    priorityLabel: trailIssuePriorityLabels[row.report.priority],
+    trailSystemName: row.systemName,
+    trailSegmentName: row.segmentName,
+    observedAt: row.report.observedAt.toISOString(),
+    createdAt: row.report.createdAt.toISOString(),
+    photoCount: row.photoCount,
+    latitude: row.report.latitude,
+    longitude: row.report.longitude,
+    locationNotes: row.report.locationNotes,
+    description: row.report.description,
+    reporterName: row.report.reporterName,
+    reporterContact: row.report.reporterContact,
+    photos,
+    notes: noteRows.map((note) => ({
+      id: note.id,
+      note: note.note,
+      authorEmail: note.authorEmail,
+      createdAt: note.createdAt.toISOString(),
+    })),
+    events: eventRows.map((event) => ({
+      id: event.id,
+      eventType: event.eventType,
+      actorLabel: event.actorLabel,
+      details: event.details ?? null,
+      createdAt: event.createdAt.toISOString(),
+    })),
+  };
+}
+
+export async function getPublicTrailMaintenanceReport(
+  publicId: string,
+): Promise<PublicTrailMaintenanceReportDetail | null> {
+  const normalizedPublicId = publicId.trim().toUpperCase();
+  const [row] = await db
+    .select({
+      report: trailMaintenanceReports,
+      systemName: trailSystems.name,
+      segmentName: trailSegments.name,
+    })
+    .from(trailMaintenanceReports)
+    .innerJoin(trailSystems, eq(trailMaintenanceReports.trailSystemId, trailSystems.id))
+    .leftJoin(trailSegments, eq(trailMaintenanceReports.trailSegmentId, trailSegments.id))
+    .where(eq(trailMaintenanceReports.publicId, normalizedPublicId))
+    .limit(1);
+
+  if (!row) return null;
+
+  const photoRows = await db
+    .select()
+    .from(trailMaintenancePhotos)
+    .where(eq(trailMaintenancePhotos.reportId, row.report.id))
+    .orderBy(asc(trailMaintenancePhotos.sortOrder), asc(trailMaintenancePhotos.createdAt));
+
+  const photos = await Promise.all(
+    photoRows.map(async (photo) => ({
+      id: photo.id,
+      url: await getTrailPhotoSignedUrl({
+        bucketName: photo.bucketName,
+        objectKey: photo.objectKey,
+      }),
+      originalFilename: photo.originalFilename,
+      contentType: photo.contentType,
+      byteSize: photo.byteSize,
+    })),
+  );
+
+  return {
+    publicId: row.report.publicId,
+    issueTypeLabel: issueTypeLabel(row.report.issueType, row.report.issueTypeOther),
+    status: row.report.status,
+    statusLabel: trailIssueStatusLabels[row.report.status],
+    priority: row.report.priority,
+    priorityLabel: trailIssuePriorityLabels[row.report.priority],
+    trailSystemName: row.systemName,
+    trailSegmentName: row.segmentName,
+    observedAt: row.report.observedAt.toISOString(),
+    createdAt: row.report.createdAt.toISOString(),
+    updatedAt: row.report.updatedAt.toISOString(),
+    resolvedAt: row.report.resolvedAt?.toISOString() ?? null,
+    latitude: row.report.latitude,
+    longitude: row.report.longitude,
+    locationNotes: row.report.locationNotes,
+    description: row.report.description,
+    photos,
+  };
+}
+
+export async function updateTrailMaintenanceReport({
+  reportId,
+  input,
+  actor,
+}: {
+  readonly reportId: string;
+  readonly input: TrailMaintenanceUpdateInput;
+  readonly actor: StaffActor;
+}): Promise<void> {
+  const staffUser = await resolveStaffUser(actor);
+  const [current] = await db
+    .select()
+    .from(trailMaintenanceReports)
+    .where(eq(trailMaintenanceReports.id, reportId))
+    .limit(1);
+  if (!current) throw new Error('Report not found');
+
+  const nextStatus = input.status ?? current.status;
+  const updates = {
+    status: nextStatus,
+    priority: input.priority ?? current.priority,
+    resolvedAt: nextStatus === 'resolved' ? (current.resolvedAt ?? new Date()) : null,
+    resolvedByUserId: nextStatus === 'resolved' ? (staffUser?.id ?? null) : null,
+    updatedAt: new Date(),
+  };
+
+  await db
+    .update(trailMaintenanceReports)
+    .set(updates)
+    .where(eq(trailMaintenanceReports.id, reportId));
+
+  if (input.status && input.status !== current.status) {
+    await db.insert(trailMaintenanceEvents).values({
+      reportId,
+      eventType: input.status === 'resolved' ? 'resolved' : 'status_changed',
+      actorUserId: staffUser?.id ?? null,
+      actorLabel: actorLabel(actor),
+      details: {from: current.status, to: input.status},
+      createdAt: new Date(),
+    });
+  }
+
+  if (input.priority && input.priority !== current.priority) {
+    await db.insert(trailMaintenanceEvents).values({
+      reportId,
+      eventType: 'priority_changed',
+      actorUserId: staffUser?.id ?? null,
+      actorLabel: actorLabel(actor),
+      details: {from: current.priority, to: input.priority},
+      createdAt: new Date(),
+    });
+  }
+
+  if (input.internalNote) {
+    await addTrailMaintenanceNote({reportId, note: input.internalNote, actor});
+  }
+}
+
+export async function addTrailMaintenanceNote({
+  reportId,
+  note,
+  actor,
+}: {
+  readonly reportId: string;
+  readonly note: string;
+  readonly actor: StaffActor;
+}): Promise<void> {
+  const staffUser = await resolveStaffUser(actor);
+  await db.insert(trailMaintenanceNotes).values({
+    reportId,
+    authorUserId: staffUser?.id ?? null,
+    authorEmail: actor.email ?? null,
+    note,
+    createdAt: new Date(),
+  });
+  await db.insert(trailMaintenanceEvents).values({
+    reportId,
+    eventType: 'note_added',
+    actorUserId: staffUser?.id ?? null,
+    actorLabel: actorLabel(actor),
+    details: {noteLength: note.length},
+    createdAt: new Date(),
+  });
+}
+
+export async function markCountyEmailGenerated({
+  reportId,
+  actor,
+}: {
+  readonly reportId: string;
+  readonly actor: StaffActor;
+}): Promise<void> {
+  const staffUser = await resolveStaffUser(actor);
+  await db
+    .update(trailMaintenanceReports)
+    .set({
+      status: 'county_needed',
+      countyEmailGeneratedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(trailMaintenanceReports.id, reportId));
+
+  await db.insert(trailMaintenanceEvents).values({
+    reportId,
+    eventType: 'county_email_generated',
+    actorUserId: staffUser?.id ?? null,
+    actorLabel: actorLabel(actor),
+    createdAt: new Date(),
+  });
+}

--- a/src/lib/trail-maintenance/turnstile.ts
+++ b/src/lib/trail-maintenance/turnstile.ts
@@ -1,0 +1,94 @@
+export interface TurnstileValidationResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+}
+
+interface TurnstileSiteverifyResponse {
+  readonly success?: boolean;
+  readonly hostname?: string;
+  readonly action?: string;
+  readonly 'error-codes'?: string[];
+}
+
+function getAllowedHostnames(): ReadonlySet<string> {
+  return new Set(
+    (process.env.CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES ?? '')
+      .split(',')
+      .map((hostname) => hostname.trim())
+      .filter(Boolean),
+  );
+}
+
+function shouldSkipTurnstile(isProduction: boolean): boolean {
+  return !isProduction && process.env.TRAIL_MAINTENANCE_SKIP_TURNSTILE === 'true';
+}
+
+export async function verifyTrailMaintenanceTurnstile({
+  token,
+  remoteIp,
+}: {
+  readonly token: string | undefined;
+  readonly remoteIp: string | null;
+}): Promise<TurnstileValidationResult> {
+  const secret = process.env.CLOUDFLARE_TURNSTILE_SECRET_KEY;
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (shouldSkipTurnstile(isProduction)) {
+    return {ok: true, reason: 'Turnstile skipped in local development'};
+  }
+
+  if (!secret) {
+    return isProduction
+      ? {ok: false, reason: 'Turnstile is not configured'}
+      : {ok: true, reason: 'Turnstile skipped outside production'};
+  }
+
+  if (!token || token.length > 2048) {
+    return {
+      ok: false,
+      reason: isProduction
+        ? 'Bot check did not complete. Reload the page and try again.'
+        : 'Bot check did not complete. For local testing, use Cloudflare Turnstile test keys or set TRAIL_MAINTENANCE_SKIP_TURNSTILE=true.',
+    };
+  }
+
+  const body = new URLSearchParams({
+    secret,
+    response: token,
+  });
+  if (remoteIp) {
+    body.set('remoteip', remoteIp);
+  }
+
+  let result: TurnstileSiteverifyResponse;
+  try {
+    const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body,
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      return {ok: false, reason: `Turnstile verification failed with ${response.status}`};
+    }
+    result = (await response.json()) as TurnstileSiteverifyResponse;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Turnstile verification failed';
+    return {ok: false, reason: message};
+  }
+
+  if (result.success !== true) {
+    return {
+      ok: false,
+      reason: result['error-codes']?.join(', ') || 'Turnstile verification failed',
+    };
+  }
+
+  const allowedHostnames = getAllowedHostnames();
+  if (allowedHostnames.size > 0 && (!result.hostname || !allowedHostnames.has(result.hostname))) {
+    return {ok: false, reason: 'Turnstile hostname is not allowed'};
+  }
+
+  return {ok: true};
+}

--- a/src/lib/trail-maintenance/validation.ts
+++ b/src/lib/trail-maintenance/validation.ts
@@ -1,0 +1,98 @@
+import {z} from 'zod';
+
+import {
+  trailIssuePriorities,
+  trailIssueStatuses,
+  trailIssueTypes,
+  trailLocationSources,
+} from './constants';
+
+const trimmedOptional = z
+  .string()
+  .trim()
+  .transform((value) => (value.length > 0 ? value : undefined))
+  .optional();
+
+const numberFromOptionalString = z.preprocess((value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? Number(trimmed) : undefined;
+}, z.number().finite().optional());
+
+export const publicTrailMaintenanceReportSchema = z
+  .object({
+    issueType: z.enum(trailIssueTypes),
+    issueTypeOther: trimmedOptional,
+    observedAt: z
+      .string()
+      .trim()
+      .min(1, 'Observed date and time is required')
+      .transform((value) => new Date(value))
+      .pipe(z.date()),
+    trailSystemSlug: z.string().trim().min(1, 'Trail system is required'),
+    trailSegmentSlug: z.string().trim().min(1, 'Trail is required'),
+    locationSource: z.enum(trailLocationSources).default('manual'),
+    locationNotes: trimmedOptional,
+    latitude: numberFromOptionalString,
+    longitude: numberFromOptionalString,
+    locationAccuracyMeters: numberFromOptionalString,
+    description: trimmedOptional,
+    reporterName: trimmedOptional,
+    reporterContact: trimmedOptional,
+    turnstileToken: trimmedOptional,
+  })
+  .superRefine((value, context) => {
+    const hasCoordinates = value.latitude !== undefined && value.longitude !== undefined;
+    if (!hasCoordinates && !value.locationNotes) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['locationNotes'],
+        message: 'Add location notes or use current location',
+      });
+    }
+
+    if (value.issueType === 'other' && !value.issueTypeOther) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['issueTypeOther'],
+        message: 'Describe the issue type',
+      });
+    }
+
+    if (value.latitude !== undefined && (value.latitude < -90 || value.latitude > 90)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['latitude'],
+        message: 'Latitude is out of range',
+      });
+    }
+
+    if (value.longitude !== undefined && (value.longitude < -180 || value.longitude > 180)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['longitude'],
+        message: 'Longitude is out of range',
+      });
+    }
+  });
+
+export const trailMaintenanceListQuerySchema = z.object({
+  status: z.enum(trailIssueStatuses).optional(),
+  priority: z.enum(trailIssuePriorities).optional(),
+  issueType: z.enum(trailIssueTypes).optional(),
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(25),
+});
+
+export const trailMaintenanceUpdateSchema = z.object({
+  status: z.enum(trailIssueStatuses).optional(),
+  priority: z.enum(trailIssuePriorities).optional(),
+  internalNote: z.string().trim().max(4000).optional(),
+});
+
+export type PublicTrailMaintenanceReportInput = z.infer<typeof publicTrailMaintenanceReportSchema>;
+export type TrailMaintenanceListQuery = z.infer<typeof trailMaintenanceListQuerySchema>;
+export type TrailMaintenanceUpdateInput = z.infer<typeof trailMaintenanceUpdateSchema>;


### PR DESCRIPTION
## Summary
- add public trail issue reporting with Turnstile validation, browser geolocation, and R2 photo storage
- add organizer/admin trail maintenance dashboard with list/detail review, status/priority updates, notes, map/photo viewing, and county email draft generation
- add trail maintenance schema, audit events, Big Branch trail seed data, and validation coverage

## Verification
- pnpm tsgo
- pnpm lint
- pnpm test:run
- pnpm fmt:check
- direnv exec . pnpm build
- direnv exec . pnpm db:migrate

## Cloudflare setup needed
- Create private R2 bucket: downeastcyclists-trail-issue-photos
- Create R2 access keys scoped to that bucket and set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME
- Create a Cloudflare Turnstile widget for the production hostname and set NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY and CLOUDFLARE_TURNSTILE_SECRET_KEY
- Set CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES to the production hostname in production; local env can include localhost
