### PR TITLE
Run database migration checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: TypeScript check
-        run: pnpm tsc
-
-      - name: TypeScript alias check
         run: pnpm tsgo
+
+      - name: Check database migrations
+        run: pnpm db:migrations:check
 
       - name: Run tests
         run: pnpm test:run

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ pnpm test:run         # Run tests once
 pnpm test:coverage    # Generate coverage report
 pnpm types:contentful # Regenerate Contentful TypeScript types
 pnpm db:generate      # Generate Drizzle migration files
+pnpm db:migrations:check # Ensure schema changes have committed migrations
 pnpm db:migrate       # Run pending database migrations
 pnpm db:push          # Push schema directly to database
 pnpm db:studio        # Launch Drizzle Studio UI
@@ -138,10 +139,11 @@ This command generates TypeScript types based on your Contentful content models.
 The primary database is PostgreSQL via Neon (serverless), managed with Drizzle ORM. Schema definitions live in `src/db/schema/` and migrations are in `drizzle/`.
 
 ```bash
-pnpm db:generate   # Generate migration from schema changes
-pnpm db:migrate    # Apply pending migrations
-pnpm db:push       # Push schema directly (development)
-pnpm db:studio     # Browse data with Drizzle Studio
+pnpm db:generate         # Generate migration from schema changes
+pnpm db:migrations:check # Ensure schema changes have committed migrations
+pnpm db:migrate          # Apply pending migrations
+pnpm db:push             # Push schema directly (development)
+pnpm db:studio           # Browse data with Drizzle Studio
 ```
 
 Trail status is stored separately in Google Firestore and managed through the admin dashboard.
@@ -150,11 +152,11 @@ Trail status is stored separately in Google Firestore and managed through the ad
 
 ### Build Configuration
 
-- **Build command**: `scripts/decrypt-credentials.sh && pnpm build`
+- **Build command**: `scripts/decrypt-credentials.sh && if [ "$CONTEXT" = "production" ]; then pnpm db:migrate; fi && pnpm build`
 - **Publish directory**: `.next`
 - **Functions directory**: `netlify/functions`
 
-Pushes to the connected GitHub repository trigger automatic builds and deploys.
+Pushes to the connected GitHub repository trigger automatic builds and deploys. Netlify applies pending committed Drizzle migrations before production builds, and GitHub CI runs `pnpm db:migrations:check` to catch schema changes that forgot to commit a matching migration file.
 
 ### Environment Variables
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "chmod +x scripts/decrypt-credentials.sh && scripts/decrypt-credentials.sh && pnpm build"
+command = "chmod +x scripts/decrypt-credentials.sh && scripts/decrypt-credentials.sh && if [ \"$CONTEXT\" = \"production\" ]; then pnpm db:migrate; fi && pnpm build"
 publish = ".next"
 functions = "netlify/functions"
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tsc": "node node_modules/@typescript/native/bin/tsc --noEmit -p tsconfig.json",
     "tsgo": "node node_modules/@typescript/native/bin/tsc --noEmit -p tsconfig.json",
     "db:generate": "drizzle-kit generate",
+    "db:migrations:check": "sh scripts/check-drizzle-migrations.sh",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",

--- a/scripts/check-drizzle-migrations.sh
+++ b/scripts/check-drizzle-migrations.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+pnpm db:generate
+
+git diff --exit-code -- drizzle
+
+status="$(git status --short --untracked-files=all -- drizzle)"
+if [ -n "$status" ]; then
+  printf '%s\n' "$status"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- run committed Drizzle migrations during Netlify production deploys before building
- add a CI migration drift check that fails when schema changes generate uncommitted `drizzle/` files
- remove the redundant `pnpm tsc` CI step now that `pnpm tsgo` is the required type check
- document the deployment and migration-check workflow

## Why

Netlify builds were not applying committed pending database migrations, and CI did not catch schema changes that forgot to include generated migration files. This makes deploys less dependent on remembering a manual migration step while keeping preview builds from mutating the production database.

## Validation

- `pnpm db:migrations:check`
- `pnpm tsgo`
- `pnpm lint`
- `pnpm test:run`
- `pnpm fmt:check`
- `NETLIFY_DATABASE_URL='postgresql://user:pass@localhost:5432/downeastcyclists' pnpm build`
