### PR TITLE
Add CSV export for trail maintenance reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The Down East Cyclists website is built with Next.js and deployed on Netlify. It
   - Member management (view, edit, import, export)
   - Payment and subscription management via Stripe
   - Trail status editing
-  - Trail maintenance report triage, priority/status updates, internal notes, embedded maps, and county escalation email drafts
+  - Trail maintenance report triage, complete CSV exports, priority/status updates, internal notes, embedded maps, and county escalation email drafts
   - Organizer access management for current members
   - QR code membership verification
   - Membership statistics and reporting

--- a/app/api/admin/trail-maintenance/reports/export/route.ts
+++ b/app/api/admin/trail-maintenance/reports/export/route.ts
@@ -1,0 +1,55 @@
+import {Effect} from 'effect';
+import {NextResponse} from 'next/server';
+
+import {handleAdminRoute} from '@/src/lib/api/admin-route-handler';
+import {DatabaseError} from '@/src/lib/effect/errors';
+import {generateTrailMaintenanceReportsCsv} from '@/src/lib/trail-maintenance/csv';
+import {listTrailMaintenanceReportsForExport} from '@/src/lib/trail-maintenance/repository';
+
+export async function GET() {
+  const response = await handleAdminRoute({
+    handler: (admin, sessionCookie) =>
+      Effect.gen(function* () {
+        yield* admin.authorize(sessionCookie, 'trail-maintenance:manage');
+        const reports = yield* Effect.tryPromise({
+          try: () => listTrailMaintenanceReportsForExport(),
+          catch: (error) =>
+            new DatabaseError({
+              code: 'TRAIL_MAINTENANCE_EXPORT_FAILED',
+              message: 'Failed to export trail maintenance reports',
+              cause: error,
+            }),
+        });
+
+        return {csv: generateTrailMaintenanceReportsCsv(reports)};
+      }),
+  });
+  const body: unknown = await response.json();
+
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'error' in body &&
+    typeof body.error === 'string'
+  ) {
+    return NextResponse.json({error: body.error}, {status: response.status});
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    !('csv' in body) ||
+    typeof body.csv !== 'string'
+  ) {
+    return NextResponse.json({error: 'Failed to export trail maintenance reports'}, {status: 500});
+  }
+
+  const date = new Date().toISOString().slice(0, 10);
+  return new NextResponse(`\uFEFF${body.csv}`, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Disposition': `attachment; filename="trail-maintenance-reports-${date}.csv"`,
+      'Content-Type': 'text/csv; charset=utf-8',
+    },
+  });
+}

--- a/src/__tests__/lib/trail-maintenance-csv.test.ts
+++ b/src/__tests__/lib/trail-maintenance-csv.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from 'vitest';
+
+import {generateTrailMaintenanceReportsCsv} from '@/src/lib/trail-maintenance/csv';
+import type {TrailMaintenanceReportSummary} from '@/src/lib/trail-maintenance/repository';
+
+const report: TrailMaintenanceReportSummary = {
+  id: 'report-1',
+  publicId: 'ABC123',
+  issueType: 'other',
+  issueTypeLabel: 'Tree, large',
+  status: 'new',
+  statusLabel: 'New',
+  priority: 'normal',
+  priorityLabel: 'Normal',
+  trailSystemName: 'Big Branch Bike Park',
+  trailSegmentName: 'Pine Loop',
+  observedAt: '2026-07-26T14:30:00.000Z',
+  createdAt: '2026-07-26T15:00:00.000Z',
+  photoCount: 2,
+  latitude: 34.75,
+  longitude: -77.42,
+  locationNotes: 'Near the "bridge"\nblocking the trail',
+};
+
+describe('generateTrailMaintenanceReportsCsv', () => {
+  it('exports report columns with quotes, commas, and line breaks escaped', () => {
+    const csv = generateTrailMaintenanceReportsCsv([report]);
+
+    expect(csv).toContain('"Report ID","Issue Type","Status","Priority"');
+    expect(csv).toContain('"Tree, large"');
+    expect(csv).toContain('"Near the ""bridge""\nblocking the trail"');
+    expect(csv).toContain('"-77.42"');
+    expect(csv).not.toContain('"\'-77.42"');
+    expect(csv.split('\r\n')).toHaveLength(2);
+  });
+
+  it('exports headers when there are no matching reports', () => {
+    const csv = generateTrailMaintenanceReportsCsv([]);
+
+    expect(csv).toContain('"Report ID"');
+    expect(csv).not.toContain('ABC123');
+  });
+
+  it('prevents user-entered values from becoming spreadsheet formulas', () => {
+    const csv = generateTrailMaintenanceReportsCsv([
+      {...report, issueTypeLabel: '=HYPERLINK("https://example.com")'},
+    ]);
+
+    expect(csv).toContain('"\'=HYPERLINK(""https://example.com"")"');
+  });
+});

--- a/src/components/admin/TrailMaintenanceManagement.tsx
+++ b/src/components/admin/TrailMaintenanceManagement.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import DownloadIcon from '@mui/icons-material/Download';
 import EmailIcon from '@mui/icons-material/Email';
 import MapIcon from '@mui/icons-material/Map';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
@@ -167,6 +168,33 @@ export function TrailMaintenanceManagement() {
     onSuccess: (draft) => setCountyDraft(draft),
   });
 
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch('/api/admin/trail-maintenance/reports/export');
+      if (!response.ok) {
+        const data: unknown = await response.json().catch(() => null);
+        const message =
+          data && typeof data === 'object' && 'error' in data && typeof data.error === 'string'
+            ? data.error
+            : 'Failed to export trail maintenance reports';
+        throw new Error(message);
+      }
+
+      const blob = await response.blob();
+      const disposition = response.headers.get('content-disposition');
+      const filename =
+        disposition?.match(/filename="([^"]+)"/)?.[1] ?? 'trail-maintenance-reports.csv';
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    },
+  });
+
   const selected = detailQuery.data;
   const mapUrl = selected ? mapsEmbedUrl(selected) : null;
 
@@ -183,26 +211,38 @@ export function TrailMaintenanceManagement() {
               emails.
             </Typography>
           </Box>
-          <Button
-            variant="outlined"
-            startIcon={<RefreshIcon />}
-            onClick={() => reportsQuery.refetch()}
-            disabled={reportsQuery.isFetching}
-          >
-            Refresh
-          </Button>
+          <Box sx={{display: 'flex', gap: 1, flexWrap: 'wrap'}}>
+            <Button
+              variant="outlined"
+              startIcon={<DownloadIcon />}
+              onClick={() => exportMutation.mutate()}
+              disabled={exportMutation.isPending || reportsQuery.isLoading}
+            >
+              {exportMutation.isPending ? 'Exporting…' : 'Export CSV'}
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<RefreshIcon />}
+              onClick={() => reportsQuery.refetch()}
+              disabled={reportsQuery.isFetching}
+            >
+              Refresh
+            </Button>
+          </Box>
         </Box>
       </Paper>
 
       {(reportsQuery.error ||
         detailQuery.error ||
         updateMutation.error ||
-        countyEmailMutation.error) && (
+        countyEmailMutation.error ||
+        exportMutation.error) && (
         <Alert severity="error">
           {reportsQuery.error?.message ||
             detailQuery.error?.message ||
             updateMutation.error?.message ||
-            countyEmailMutation.error?.message}
+            countyEmailMutation.error?.message ||
+            exportMutation.error?.message}
         </Alert>
       )}
 

--- a/src/lib/trail-maintenance/csv.ts
+++ b/src/lib/trail-maintenance/csv.ts
@@ -1,0 +1,50 @@
+import type {TrailMaintenanceReportSummary} from './repository';
+
+const csvHeaders = [
+  'Report ID',
+  'Issue Type',
+  'Status',
+  'Priority',
+  'Trail System',
+  'Trail Segment',
+  'Observed At',
+  'Submitted At',
+  'Photo Count',
+  'Latitude',
+  'Longitude',
+  'Location Notes',
+] as const;
+
+function protectSpreadsheetFormula(value: string): string {
+  return /^\s*[=+\-@]/.test(value) ? `'${value}` : value;
+}
+
+function escapeCsvCell(value: string | number | null): string {
+  const stringValue = value === null ? '' : String(value);
+  const protectedValue = typeof value === 'string' ? protectSpreadsheetFormula(value) : stringValue;
+  return `"${protectedValue.replaceAll('"', '""')}"`;
+}
+
+export function generateTrailMaintenanceReportsCsv(
+  reports: ReadonlyArray<TrailMaintenanceReportSummary>,
+): string {
+  const rows = reports.map((report) => [
+    report.publicId,
+    report.issueTypeLabel,
+    report.statusLabel,
+    report.priorityLabel,
+    report.trailSystemName,
+    report.trailSegmentName,
+    report.observedAt,
+    report.createdAt,
+    report.photoCount,
+    report.latitude,
+    report.longitude,
+    report.locationNotes,
+  ]);
+
+  return [
+    csvHeaders.map(escapeCsvCell).join(','),
+    ...rows.map((row) => row.map(escapeCsvCell).join(',')),
+  ].join('\r\n');
+}

--- a/src/lib/trail-maintenance/repository.ts
+++ b/src/lib/trail-maintenance/repository.ts
@@ -282,17 +282,40 @@ export async function getTrailMaintenanceReportRecipients(): Promise<string[]> {
 export async function listTrailMaintenanceReports(
   query: TrailMaintenanceListQuery,
 ): Promise<TrailMaintenanceListResult> {
+  const offset = (query.page - 1) * query.pageSize;
+  const where = trailMaintenanceReportWhere(query);
+
+  const [totalRows, reports] = await Promise.all([
+    db.select({count: count()}).from(trailMaintenanceReports).where(where),
+    selectTrailMaintenanceReportSummaries(query, {limit: query.pageSize, offset}),
+  ]);
+
+  return {
+    total: totalRows[0]?.count ?? 0,
+    reports,
+  };
+}
+
+export function listTrailMaintenanceReportsForExport(): Promise<TrailMaintenanceReportSummary[]> {
+  return selectTrailMaintenanceReportSummaries({});
+}
+
+type TrailMaintenanceFilters = Pick<TrailMaintenanceListQuery, 'status' | 'priority' | 'issueType'>;
+
+function trailMaintenanceReportWhere(query: TrailMaintenanceFilters) {
   const conditions = [
     query.status ? eq(trailMaintenanceReports.status, query.status) : undefined,
     query.priority ? eq(trailMaintenanceReports.priority, query.priority) : undefined,
     query.issueType ? eq(trailMaintenanceReports.issueType, query.issueType) : undefined,
   ].filter((condition) => condition !== undefined);
-  const where = conditions.length > 0 ? and(...conditions) : undefined;
-  const offset = (query.page - 1) * query.pageSize;
+  return conditions.length > 0 ? and(...conditions) : undefined;
+}
 
-  const totalRows = await db.select({count: count()}).from(trailMaintenanceReports).where(where);
-
-  const rows = await db
+async function selectTrailMaintenanceReportSummaries(
+  query: TrailMaintenanceFilters,
+  pagination?: {readonly limit: number; readonly offset: number},
+): Promise<TrailMaintenanceReportSummary[]> {
+  const databaseQuery = db
     .select({
       report: trailMaintenanceReports,
       systemName: trailSystems.name,
@@ -306,33 +329,32 @@ export async function listTrailMaintenanceReports(
       trailMaintenancePhotos,
       eq(trailMaintenanceReports.id, trailMaintenancePhotos.reportId),
     )
-    .where(where)
+    .where(trailMaintenanceReportWhere(query))
     .groupBy(trailMaintenanceReports.id, trailSystems.name, trailSegments.name)
-    .orderBy(desc(trailMaintenanceReports.createdAt))
-    .limit(query.pageSize)
-    .offset(offset);
+    .orderBy(desc(trailMaintenanceReports.createdAt));
 
-  return {
-    total: totalRows[0]?.count ?? 0,
-    reports: rows.map((row) => ({
-      id: row.report.id,
-      publicId: row.report.publicId,
-      issueType: row.report.issueType,
-      issueTypeLabel: issueTypeLabel(row.report.issueType, row.report.issueTypeOther),
-      status: row.report.status,
-      statusLabel: trailIssueStatusLabels[row.report.status],
-      priority: row.report.priority,
-      priorityLabel: trailIssuePriorityLabels[row.report.priority],
-      trailSystemName: row.systemName,
-      trailSegmentName: row.segmentName,
-      observedAt: row.report.observedAt.toISOString(),
-      createdAt: row.report.createdAt.toISOString(),
-      photoCount: row.photoCount,
-      latitude: row.report.latitude,
-      longitude: row.report.longitude,
-      locationNotes: row.report.locationNotes,
-    })),
-  };
+  const rows = pagination
+    ? await databaseQuery.limit(pagination.limit).offset(pagination.offset)
+    : await databaseQuery;
+
+  return rows.map((row) => ({
+    id: row.report.id,
+    publicId: row.report.publicId,
+    issueType: row.report.issueType,
+    issueTypeLabel: issueTypeLabel(row.report.issueType, row.report.issueTypeOther),
+    status: row.report.status,
+    statusLabel: trailIssueStatusLabels[row.report.status],
+    priority: row.report.priority,
+    priorityLabel: trailIssuePriorityLabels[row.report.priority],
+    trailSystemName: row.systemName,
+    trailSegmentName: row.segmentName,
+    observedAt: row.report.observedAt.toISOString(),
+    createdAt: row.report.createdAt.toISOString(),
+    photoCount: row.photoCount,
+    latitude: row.report.latitude,
+    longitude: row.report.longitude,
+    locationNotes: row.report.locationNotes,
+  }));
 }
 
 export async function getTrailMaintenanceReportDetail(


### PR DESCRIPTION
## Summary

- add an **Export CSV** action to the admin trail maintenance reports page
- export the complete report history regardless of the on-screen status filter
- protect the download with the existing trail-maintenance admin permission
- include report, status, priority, trail, timestamp, photo, coordinate, and location-note columns
- escape CSV values safely, including spreadsheet-formula protection for user-entered text
- document the admin CSV export and add focused unit coverage

## Validation

- `pnpm tsgo`
- `pnpm lint`
- `pnpm test:run` (286 tests)
- `pnpm fmt:check`
- `pnpm build` (with a build-only `NETLIFY_DATABASE_URL` in the isolated worktree)
