### PR TITLE
Upload trail report photos directly to R2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,7 @@ NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=0x4AAAAAA-your-site-key
 CLOUDFLARE_TURNSTILE_SECRET_KEY=0x4AAAAAA-your-secret-key
 CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES=localhost,downeastcyclists.com
 TRAIL_MAINTENANCE_SKIP_TURNSTILE=false
+TRAIL_MAINTENANCE_UPLOAD_SECRET=replace-with-an-independent-random-secret-at-least-32-characters
 
 # Cloudflare R2 private bucket for submitted trail issue photos.
 R2_ACCOUNT_ID=your-cloudflare-account-id

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The Down East Cyclists website is built with Next.js and deployed on Netlify. It
 - **Report Trail Issue** (`/report-trail-issue`): Public form for riders to report Big Branch trail maintenance issues
   - Supports issue type selection, observed date/time, trail segment, location notes, browser geolocation, optional reporter contact, and up to three photos
   - Uses Cloudflare Turnstile when configured
+  - Uploads photos directly from the browser to short-lived private R2 staging objects, then validates and normalizes them server-side when the report is finalized
   - Redirects submitters to a public confirmation/status page (`/report-trail-issue/[publicId]`)
 
 ### Contact
@@ -258,14 +259,43 @@ The following environment variables need to be set in Netlify:
 
 - `NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY`: Public Turnstile site key used by the trail issue report form.
 - `CLOUDFLARE_TURNSTILE_SECRET_KEY`: Server-side Turnstile verification secret.
-- `CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES`: Optional comma-separated list of hostnames accepted during Turnstile verification.
+- `CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES`: Comma-separated list of hostnames accepted during Turnstile verification; required in production.
 - `TRAIL_MAINTENANCE_SKIP_TURNSTILE`: Set to `true` outside production to bypass Turnstile during local testing.
+- `TRAIL_MAINTENANCE_UPLOAD_SECRET`: Independent random secret of at least 32 characters used to sign the short-lived photo upload session created after Turnstile verification.
 - `R2_ACCOUNT_ID`: Cloudflare R2 account ID for trail issue photo storage.
 - `R2_ACCESS_KEY_ID`: R2 access key ID.
 - `R2_SECRET_ACCESS_KEY`: R2 secret access key.
 - `R2_BUCKET_NAME`: R2 bucket name for uploaded report photos.
 - `QR_SIGNING_SECRET`: Secret used when signing trail report rate-limit identifiers and QR/prefill tokens.
 - `ONSLOW_PARKS_EMAIL`: Recipient used when drafting Onslow County Parks and Recreation escalation emails.
+
+The private R2 bucket must allow browser `PUT` requests from each deployed site origin. Configure
+the bucket CORS policy in Cloudflare with the production and local origins used by this project:
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://downeastcyclists.com",
+      "https://downeast.netlify.app",
+      "http://localhost:3000",
+      "http://localhost:8888"
+    ],
+    "AllowedMethods": ["PUT"],
+    "AllowedHeaders": ["Content-Type"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3600
+  }
+]
+```
+
+Add an explicit origin to the R2 CORS policy and its hostname to
+`CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES` for any deploy preview used to exercise photo uploads.
+Presigned upload URLs are valid for 15 minutes, accept only the declared content type, and target a
+private staging key. The report endpoint verifies the stored byte count and content type, decodes
+and converts each image to WebP, writes the final objects, and removes the staging objects. Also add
+an R2 object lifecycle rule that expires objects under `trail-maintenance-staging/` after one day so
+abandoned or partially completed uploads are removed automatically.
 
 **Meetup event ingestion:**
 

--- a/app/api/trail-maintenance/reports/route.ts
+++ b/app/api/trail-maintenance/reports/route.ts
@@ -1,12 +1,8 @@
 import {NextRequest, NextResponse} from 'next/server';
 
-import {
-  TRAIL_MAINTENANCE_PHOTO_LIMIT,
-  TRAIL_MAINTENANCE_PHOTO_MAX_BYTES,
-} from '@/src/lib/trail-maintenance/constants';
 import {sendTrailMaintenanceNotification} from '@/src/lib/trail-maintenance/notifications';
 import {
-  storeTrailMaintenancePhotos,
+  storeTrailMaintenancePhotosFromUploads,
   TrailPhotoValidationError,
 } from '@/src/lib/trail-maintenance/r2';
 import {
@@ -14,62 +10,20 @@ import {
   getTrailMaintenanceReportDetail,
   getTrailMaintenanceReportRecipients,
 } from '@/src/lib/trail-maintenance/repository';
-import {verifyTrailMaintenanceTurnstile} from '@/src/lib/trail-maintenance/turnstile';
-import {publicTrailMaintenanceReportSchema} from '@/src/lib/trail-maintenance/validation';
-
-function getClientIp(request: NextRequest): string | null {
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) return forwardedFor.split(',')[0]?.trim() || null;
-  return request.headers.get('x-real-ip');
-}
-
-function formValue(formData: FormData, key: string): string | undefined {
-  const value = formData.get(key);
-  return typeof value === 'string' ? value : undefined;
-}
-
-function getPhotoFiles(formData: FormData): File[] {
-  return formData
-    .getAll('photos')
-    .filter((value): value is File => value instanceof File && value.size > 0);
-}
+import {getTrailMaintenanceClientIp} from '@/src/lib/trail-maintenance/request';
+import {verifyTrailPhotoUploadSession} from '@/src/lib/trail-maintenance/upload-session';
+import {publicTrailMaintenanceReportSubmissionSchema} from '@/src/lib/trail-maintenance/validation';
 
 export async function POST(request: NextRequest) {
   try {
-    const contentLength = Number(request.headers.get('content-length'));
-    const maximumRequestBytes =
-      TRAIL_MAINTENANCE_PHOTO_LIMIT * TRAIL_MAINTENANCE_PHOTO_MAX_BYTES + 1024 * 1024;
-    if (Number.isFinite(contentLength) && contentLength > maximumRequestBytes) {
-      return NextResponse.json({error: 'Upload is too large'}, {status: 413});
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({error: 'Invalid report'}, {status: 400});
     }
 
-    const formData = await request.formData();
-    const photoFiles = getPhotoFiles(formData);
-    if (photoFiles.length > TRAIL_MAINTENANCE_PHOTO_LIMIT) {
-      return NextResponse.json(
-        {error: `Upload up to ${TRAIL_MAINTENANCE_PHOTO_LIMIT} photos`},
-        {status: 400},
-      );
-    }
-
-    const parsed = publicTrailMaintenanceReportSchema.safeParse({
-      issueType: formValue(formData, 'issueType'),
-      issueTypeOther: formValue(formData, 'issueTypeOther'),
-      observedAt: formValue(formData, 'observedAt'),
-      trailSystemSlug: formValue(formData, 'trailSystemSlug'),
-      trailSegmentSlug: formValue(formData, 'trailSegmentSlug'),
-      locationSource: formValue(formData, 'locationSource') || 'manual',
-      locationNotes: formValue(formData, 'locationNotes'),
-      latitude: formValue(formData, 'latitude'),
-      longitude: formValue(formData, 'longitude'),
-      locationAccuracyMeters: formValue(formData, 'locationAccuracyMeters'),
-      description: formValue(formData, 'description'),
-      reporterName: formValue(formData, 'reporterName'),
-      reporterContact: formValue(formData, 'reporterContact'),
-      turnstileToken:
-        formValue(formData, 'cf-turnstile-response') || formValue(formData, 'turnstileToken'),
-    });
-
+    const parsed = publicTrailMaintenanceReportSubmissionSchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json(
         {error: parsed.error.issues[0]?.message || 'Invalid report'},
@@ -77,25 +31,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const remoteIp = getClientIp(request);
-    const turnstile = await verifyTrailMaintenanceTurnstile({
-      token: parsed.data.turnstileToken,
-      remoteIp,
-    });
-    if (!turnstile.ok) {
-      return NextResponse.json({error: turnstile.reason || 'Bot check failed'}, {status: 403});
+    const uploadSession = verifyTrailPhotoUploadSession(parsed.data.uploadToken);
+    if (!uploadSession.ok) {
+      return NextResponse.json(
+        {error: 'Photo upload session is invalid or expired. Please try again.'},
+        {status: 400},
+      );
     }
 
-    const publicId = crypto.randomUUID().replace(/-/g, '').slice(0, 12).toUpperCase();
-    const photos = await storeTrailMaintenancePhotos({
-      publicId,
-      files: photoFiles,
+    const {uploadToken: _uploadToken, ...input} = parsed.data;
+    const photos = await storeTrailMaintenancePhotosFromUploads({
+      publicId: uploadSession.payload.publicId,
+      files: uploadSession.payload.files,
     });
-
+    const remoteIp = getTrailMaintenanceClientIp(request);
     const created = await createTrailMaintenanceReport({
-      input: parsed.data,
+      input,
       photos,
-      publicId,
+      publicId: uploadSession.payload.publicId,
       userAgent: request.headers.get('user-agent'),
       remoteIp,
     });

--- a/app/api/trail-maintenance/reports/uploads/route.ts
+++ b/app/api/trail-maintenance/reports/uploads/route.ts
@@ -1,0 +1,45 @@
+import {NextRequest, NextResponse} from 'next/server';
+
+import {createTrailPhotoUploadTargets} from '@/src/lib/trail-maintenance/r2';
+import {getTrailMaintenanceClientIp} from '@/src/lib/trail-maintenance/request';
+import {verifyTrailMaintenanceTurnstile} from '@/src/lib/trail-maintenance/turnstile';
+import {
+  createTrailPhotoUploadSession,
+  trailPhotoUploadRequestSchema,
+} from '@/src/lib/trail-maintenance/upload-session';
+
+export async function POST(request: NextRequest) {
+  try {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({error: 'Invalid upload request'}, {status: 400});
+    }
+
+    const parsed = trailPhotoUploadRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {error: parsed.error.issues[0]?.message || 'Invalid upload request'},
+        {status: 400},
+      );
+    }
+
+    const turnstile = await verifyTrailMaintenanceTurnstile({
+      token: parsed.data.turnstileToken,
+      remoteIp: getTrailMaintenanceClientIp(request),
+    });
+    if (!turnstile.ok) {
+      return NextResponse.json({error: turnstile.reason || 'Bot check failed'}, {status: 403});
+    }
+
+    const now = new Date();
+    const session = createTrailPhotoUploadSession(parsed.data.files, now);
+    const uploads = await createTrailPhotoUploadTargets({files: session.payload.files, now});
+
+    return NextResponse.json({uploadToken: session.token, uploads}, {status: 201});
+  } catch (error) {
+    console.error('[TrailMaintenance] Failed to create photo upload session:', error);
+    return NextResponse.json({error: 'Failed to prepare photo uploads'}, {status: 500});
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tanstack/pacer": "^0.17.3",
     "@tanstack/react-pacer": "^0.19.3",
     "@tanstack/react-query": "5.66.11",
+    "aws4fetch": "1.0.20",
     "clsx": "2.1.1",
     "contentful": "^11.12.7",
     "drizzle-orm": "^0.45.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.66.11
         version: 5.66.11(react@19.2.4)
+      aws4fetch:
+        specifier: 1.0.20
+        version: 1.0.20
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -191,7 +194,7 @@ importers:
         version: 15.5.21(eslint@8.57.1)(typescript@5.8.2)
       netlify-cli:
         specifier: ^22.2.1
-        version: 22.4.0(@types/node@20.19.25)(picomatch@4.0.3)(rollup@4.55.1)
+        version: 22.4.0(@types/node@20.19.25)(aws4fetch@1.0.20)(picomatch@4.0.3)(rollup@4.55.1)
       oxfmt:
         specifier: ^0.24.0
         version: 0.24.0
@@ -3377,6 +3380,9 @@ packages:
 
   avvio@8.4.0:
     resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
+
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
@@ -11684,6 +11690,8 @@ snapshots:
       '@fastify/error': 3.4.1
       fastq: 1.19.1
 
+  aws4fetch@1.0.20: {}
+
   axe-core@4.11.0: {}
 
   axios@1.13.2:
@@ -14189,7 +14197,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipx@3.1.1(@netlify/blobs@10.0.7)(@types/node@20.19.25):
+  ipx@3.1.1(@netlify/blobs@10.0.7)(@types/node@20.19.25)(aws4fetch@1.0.20):
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       citty: 0.1.6
@@ -14205,7 +14213,7 @@ snapshots:
       sharp: 0.35.3(@types/node@20.19.25)
       svgo: 4.0.0
       ufo: 1.6.1
-      unstorage: 1.17.3(@netlify/blobs@10.0.7)
+      unstorage: 1.17.3(@netlify/blobs@10.0.7)(aws4fetch@1.0.20)
       xss: 1.0.15
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15359,7 +15367,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  netlify-cli@22.4.0(@types/node@20.19.25)(picomatch@4.0.3)(rollup@4.55.1):
+  netlify-cli@22.4.0(@types/node@20.19.25)(aws4fetch@1.0.20)(picomatch@4.0.3)(rollup@4.55.1):
     dependencies:
       '@fastify/static': 7.0.4
       '@netlify/api': 14.0.3
@@ -15416,7 +15424,7 @@ snapshots:
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       inquirer: 8.2.6
       inquirer-autocomplete-prompt: 1.4.0(inquirer@8.2.6)
-      ipx: 3.1.1(@netlify/blobs@10.0.7)(@types/node@20.19.25)
+      ipx: 3.1.1(@netlify/blobs@10.0.7)(@types/node@20.19.25)(aws4fetch@1.0.20)
       is-docker: 3.0.0
       is-stream: 4.0.1
       is-wsl: 3.1.0
@@ -17455,7 +17463,7 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  unstorage@1.17.3(@netlify/blobs@10.0.7):
+  unstorage@1.17.3(@netlify/blobs@10.0.7)(aws4fetch@1.0.20):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -17467,6 +17475,7 @@ snapshots:
       ufo: 1.6.1
     optionalDependencies:
       '@netlify/blobs': 10.0.7
+      aws4fetch: 1.0.20
 
   untildify@4.0.0: {}
 

--- a/src/__tests__/lib/trail-direct-r2-upload.test.ts
+++ b/src/__tests__/lib/trail-direct-r2-upload.test.ts
@@ -1,0 +1,150 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  createTrailPhotoUploadTargets,
+  storeTrailMaintenancePhotosFromUploads,
+  TrailPhotoValidationError,
+} from '@/src/lib/trail-maintenance/r2';
+import {createTrailPhotoUploadSession} from '@/src/lib/trail-maintenance/upload-session';
+
+const NOW = new Date('2026-08-06T19:00:00.000Z');
+const ONE_PIXEL_PNG = Uint8Array.from(
+  Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+    'base64',
+  ),
+);
+
+function pngBody(): ArrayBuffer {
+  const copy = new Uint8Array(ONE_PIXEL_PNG.byteLength);
+  copy.set(ONE_PIXEL_PNG);
+  return copy.buffer;
+}
+
+beforeEach(() => {
+  process.env.R2_ACCOUNT_ID = 'test-account';
+  process.env.R2_ACCESS_KEY_ID = 'test-access-key';
+  process.env.R2_SECRET_ACCESS_KEY = 'test-secret-key';
+  process.env.R2_BUCKET_NAME = 'test-bucket';
+  process.env.TRAIL_MAINTENANCE_UPLOAD_SECRET = 'test-upload-secret-that-is-at-least-32-characters';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('direct R2 trail photo uploads', () => {
+  it('creates content-type-bound PUT URLs with a 15-minute expiry', async () => {
+    const session = createTrailPhotoUploadSession(
+      [
+        {
+          originalFilename: 'trail.png',
+          contentType: 'image/png',
+          byteSize: ONE_PIXEL_PNG.byteLength,
+        },
+      ],
+      NOW,
+    );
+
+    const [target] = await createTrailPhotoUploadTargets({files: session.payload.files, now: NOW});
+
+    expect(target).toBeDefined();
+    if (!target) return;
+    const url = new URL(target.uploadUrl);
+    expect(url.hostname).toBe('test-account.r2.cloudflarestorage.com');
+    expect(url.pathname).toContain('/test-bucket/trail-maintenance-staging/');
+    expect(url.searchParams.get('X-Amz-Expires')).toBe('900');
+    expect(url.searchParams.get('X-Amz-SignedHeaders')).toBe('content-type;host');
+    expect(url.searchParams.get('X-Amz-Signature')).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('revalidates, normalizes, stores, and removes a staged upload', async () => {
+    const session = createTrailPhotoUploadSession(
+      [
+        {
+          originalFilename: 'trail.png',
+          contentType: 'image/png',
+          byteSize: ONE_PIXEL_PNG.byteLength,
+        },
+      ],
+      NOW,
+    );
+    const methods: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        methods.push(method);
+        if (method === 'HEAD') {
+          return new Response(null, {
+            status: 200,
+            headers: {
+              'Content-Length': String(ONE_PIXEL_PNG.byteLength),
+              'Content-Type': 'image/png',
+            },
+          });
+        }
+        if (method === 'GET') {
+          return new Response(pngBody(), {
+            status: 200,
+            headers: {'Content-Length': String(ONE_PIXEL_PNG.byteLength)},
+          });
+        }
+        return new Response(null, {status: method === 'DELETE' ? 204 : 200});
+      }),
+    );
+
+    const stored = await storeTrailMaintenancePhotosFromUploads({
+      publicId: session.payload.publicId,
+      files: session.payload.files,
+    });
+
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      contentType: 'image/webp',
+      originalFilename: 'trail.webp',
+      sortOrder: 0,
+    });
+    expect(stored[0]?.objectKey).toBe(`trail-maintenance/${session.payload.publicId}/1.webp`);
+    expect(methods).toEqual(['HEAD', 'GET', 'PUT', 'DELETE']);
+  });
+
+  it('rejects an object whose stored size differs and still removes staging', async () => {
+    const session = createTrailPhotoUploadSession(
+      [
+        {
+          originalFilename: 'trail.png',
+          contentType: 'image/png',
+          byteSize: ONE_PIXEL_PNG.byteLength,
+        },
+      ],
+      NOW,
+    );
+    const methods: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        methods.push(method);
+        if (method === 'HEAD') {
+          return new Response(null, {
+            status: 200,
+            headers: {
+              'Content-Length': String(ONE_PIXEL_PNG.byteLength + 1),
+              'Content-Type': 'image/png',
+            },
+          });
+        }
+        return new Response(null, {status: 204});
+      }),
+    );
+
+    await expect(
+      storeTrailMaintenancePhotosFromUploads({
+        publicId: session.payload.publicId,
+        files: session.payload.files,
+      }),
+    ).rejects.toBeInstanceOf(TrailPhotoValidationError);
+    expect(methods).toEqual(['HEAD', 'DELETE']);
+  });
+});

--- a/src/__tests__/lib/trail-maintenance-turnstile.test.ts
+++ b/src/__tests__/lib/trail-maintenance-turnstile.test.ts
@@ -1,0 +1,50 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {TRAIL_MAINTENANCE_TURNSTILE_ACTION} from '@/src/lib/trail-maintenance/constants';
+import {verifyTrailMaintenanceTurnstile} from '@/src/lib/trail-maintenance/turnstile';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.CLOUDFLARE_TURNSTILE_SECRET_KEY;
+  delete process.env.CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES;
+});
+
+describe('trail maintenance Turnstile verification', () => {
+  it('accepts the expected action and hostname', async () => {
+    process.env.CLOUDFLARE_TURNSTILE_SECRET_KEY = 'turnstile-secret';
+    process.env.CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES = 'downeastcyclists.com';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({
+          success: true,
+          action: TRAIL_MAINTENANCE_TURNSTILE_ACTION,
+          hostname: 'downeastcyclists.com',
+        }),
+      ),
+    );
+
+    await expect(
+      verifyTrailMaintenanceTurnstile({token: 'valid-token', remoteIp: '192.0.2.1'}),
+    ).resolves.toEqual({ok: true});
+  });
+
+  it('rejects a token issued for a different action', async () => {
+    process.env.CLOUDFLARE_TURNSTILE_SECRET_KEY = 'turnstile-secret';
+    process.env.CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES = 'downeastcyclists.com';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({
+          success: true,
+          action: 'different_action',
+          hostname: 'downeastcyclists.com',
+        }),
+      ),
+    );
+
+    await expect(
+      verifyTrailMaintenanceTurnstile({token: 'valid-token', remoteIp: null}),
+    ).resolves.toEqual({ok: false, reason: 'Turnstile action is not allowed'});
+  });
+});

--- a/src/__tests__/lib/trail-upload-session.test.ts
+++ b/src/__tests__/lib/trail-upload-session.test.ts
@@ -1,0 +1,69 @@
+import {describe, expect, it} from 'vitest';
+
+import {
+  createTrailPhotoUploadSession,
+  trailPhotoUploadRequestSchema,
+  verifyTrailPhotoUploadSession,
+} from '@/src/lib/trail-maintenance/upload-session';
+
+const NOW = new Date('2026-08-06T19:00:00.000Z');
+const PHOTO = {
+  originalFilename: 'trail obstruction.jpg',
+  contentType: 'image/jpeg',
+  byteSize: 4_000_000,
+};
+
+describe('trail photo upload sessions', () => {
+  it('creates a signed session with private, ordered staging keys', () => {
+    process.env.TRAIL_MAINTENANCE_UPLOAD_SECRET =
+      'test-upload-secret-that-is-at-least-32-characters';
+
+    const session = createTrailPhotoUploadSession([PHOTO, {...PHOTO, byteSize: 2_000_000}], NOW);
+    const verification = verifyTrailPhotoUploadSession(session.token, NOW);
+
+    expect(verification.ok).toBe(true);
+    if (!verification.ok) return;
+    expect(verification.payload.files).toHaveLength(2);
+    expect(verification.payload.files[0]?.sortOrder).toBe(0);
+    expect(verification.payload.files[0]?.objectKey).toMatch(
+      new RegExp(`^trail-maintenance-staging/${verification.payload.publicId}/1-`),
+    );
+    expect(verification.payload.exp - verification.payload.iat).toBe(15 * 60);
+  });
+
+  it('rejects tampered and expired sessions', () => {
+    process.env.TRAIL_MAINTENANCE_UPLOAD_SECRET =
+      'test-upload-secret-that-is-at-least-32-characters';
+
+    const session = createTrailPhotoUploadSession([PHOTO], NOW);
+    const tampered = `${session.token.slice(0, -1)}x`;
+
+    expect(verifyTrailPhotoUploadSession(tampered, NOW)).toEqual({ok: false});
+    expect(
+      verifyTrailPhotoUploadSession(session.token, new Date(NOW.getTime() + 15 * 60_000)),
+    ).toEqual({ok: false});
+  });
+
+  it('enforces the upload count, content type, and per-photo size before signing', () => {
+    expect(
+      trailPhotoUploadRequestSchema.safeParse({
+        files: [PHOTO, PHOTO, PHOTO],
+      }).success,
+    ).toBe(true);
+    expect(
+      trailPhotoUploadRequestSchema.safeParse({
+        files: [PHOTO, PHOTO, PHOTO, PHOTO],
+      }).success,
+    ).toBe(false);
+    expect(
+      trailPhotoUploadRequestSchema.safeParse({
+        files: [{...PHOTO, contentType: 'image/svg+xml'}],
+      }).success,
+    ).toBe(false);
+    expect(
+      trailPhotoUploadRequestSchema.safeParse({
+        files: [{...PHOTO, byteSize: 10 * 1024 * 1024 + 1}],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/components/trail-maintenance/PublicTrailIssueReportForm.tsx
+++ b/src/components/trail-maintenance/PublicTrailIssueReportForm.tsx
@@ -20,15 +20,106 @@ import {
 import Grid from '@mui/material/Grid2';
 import {useRouter, useSearchParams} from 'next/navigation';
 import Script from 'next/script';
-import {FormEvent, useEffect, useMemo, useState} from 'react';
+import {FormEvent, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {
   TRAIL_MAINTENANCE_PHOTO_LIMIT,
+  TRAIL_MAINTENANCE_PHOTO_MAX_BYTES,
+  TRAIL_MAINTENANCE_TURNSTILE_ACTION,
   TRAIL_SYSTEM_BIG_BRANCH,
+  trailMaintenancePhotoContentTypes,
   trailIssueTypeLabels,
   trailIssueTypes,
 } from '@/src/lib/trail-maintenance/constants';
 import type {TrailMaintenanceOption} from '@/src/lib/trail-maintenance/repository';
+
+type TurnstileWidgetId = string;
+type TurnstileApi = {
+  render: (
+    container: HTMLElement,
+    options: {
+      sitekey: string;
+      action: string;
+      callback: (token: string) => void;
+      'expired-callback': () => void;
+      'error-callback': () => void;
+    },
+  ) => TurnstileWidgetId;
+  reset: (widgetId: TurnstileWidgetId) => void;
+};
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+interface TrailPhotoUploadTarget {
+  readonly uploadUrl: string;
+  readonly contentType: string;
+  readonly sortOrder: number;
+}
+
+interface TrailPhotoUploadSessionResponse {
+  readonly uploadToken: string;
+  readonly uploads: readonly TrailPhotoUploadTarget[];
+}
+
+interface TrailReportResponse {
+  readonly publicId: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function errorMessage(value: unknown, fallback: string): string {
+  return isRecord(value) && typeof value.error === 'string' ? value.error : fallback;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function decodeUploadSession(value: unknown): TrailPhotoUploadSessionResponse | null {
+  if (!isRecord(value) || typeof value.uploadToken !== 'string' || !Array.isArray(value.uploads)) {
+    return null;
+  }
+
+  const uploads: TrailPhotoUploadTarget[] = [];
+  for (const upload of value.uploads) {
+    if (
+      !isRecord(upload) ||
+      typeof upload.uploadUrl !== 'string' ||
+      typeof upload.contentType !== 'string' ||
+      typeof upload.sortOrder !== 'number'
+    ) {
+      return null;
+    }
+    uploads.push({
+      uploadUrl: upload.uploadUrl,
+      contentType: upload.contentType,
+      sortOrder: upload.sortOrder,
+    });
+  }
+
+  return {uploadToken: value.uploadToken, uploads};
+}
+
+function decodeTrailReport(value: unknown): TrailReportResponse | null {
+  return isRecord(value) && typeof value.publicId === 'string' ? {publicId: value.publicId} : null;
+}
+
+function formString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value : '';
+}
 
 function localDateTimeValue(date: Date): string {
   const offsetMs = date.getTimezoneOffset() * 60_000;
@@ -38,6 +129,8 @@ function localDateTimeValue(date: Date): string {
 export function PublicTrailIssueReportForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const turnstileContainer = useRef<HTMLDivElement>(null);
+  const turnstileWidgetId = useRef<TurnstileWidgetId | null>(null);
   const [options, setOptions] = useState<TrailMaintenanceOption[]>([]);
   const [trailSystemSlug, setTrailSystemSlug] = useState(
     searchParams?.get('system') || TRAIL_SYSTEM_BIG_BRANCH,
@@ -54,12 +147,39 @@ export function PublicTrailIssueReportForm() {
     {type: 'success' | 'error'; message: string} | undefined
   >();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState('');
 
   const selectedSystem = useMemo(
     () => options.find((option) => option.slug === trailSystemSlug),
     [options, trailSystemSlug],
   );
   const siteKey = process.env.NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY;
+
+  const renderTurnstile = useCallback(() => {
+    if (
+      !siteKey ||
+      !turnstileContainer.current ||
+      turnstileWidgetId.current !== null ||
+      !window.turnstile
+    ) {
+      return;
+    }
+
+    turnstileWidgetId.current = window.turnstile.render(turnstileContainer.current, {
+      sitekey: siteKey,
+      action: TRAIL_MAINTENANCE_TURNSTILE_ACTION,
+      callback: setTurnstileToken,
+      'expired-callback': () => setTurnstileToken(''),
+      'error-callback': () => setTurnstileToken(''),
+    });
+  }, [siteKey]);
+
+  const resetTurnstile = useCallback(() => {
+    if (turnstileWidgetId.current !== null && window.turnstile) {
+      window.turnstile.reset(turnstileWidgetId.current);
+    }
+    setTurnstileToken('');
+  }, []);
 
   useEffect(() => {
     let isMounted = true;
@@ -120,8 +240,7 @@ export function PublicTrailIssueReportForm() {
     formData.set('longitude', longitude);
     formData.set('locationAccuracyMeters', accuracy);
 
-    const turnstileToken = formData.get('cf-turnstile-response');
-    if (siteKey && (typeof turnstileToken !== 'string' || turnstileToken.length === 0)) {
+    if (siteKey && turnstileToken.length === 0) {
       setSubmitStatus({
         type: 'error',
         message:
@@ -132,21 +251,97 @@ export function PublicTrailIssueReportForm() {
     }
 
     try {
-      const response = await fetch('/api/trail-maintenance/reports', {
-        method: 'POST',
-        body: formData,
-      });
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.error || 'Report could not be submitted');
+      const photos = formData
+        .getAll('photos')
+        .filter((value): value is File => value instanceof File && value.size > 0);
+      if (photos.length > TRAIL_MAINTENANCE_PHOTO_LIMIT) {
+        throw new Error(`Upload up to ${TRAIL_MAINTENANCE_PHOTO_LIMIT} photos`);
       }
-      router.push(`/report-trail-issue/${encodeURIComponent(data.publicId)}`);
+      for (const photo of photos) {
+        if (photo.size > TRAIL_MAINTENANCE_PHOTO_MAX_BYTES) {
+          throw new Error('Photos must be no larger than 10 MB');
+        }
+        if (!trailMaintenancePhotoContentTypes.includes(photo.type)) {
+          throw new Error('Photos must be JPEG, PNG, or WebP images');
+        }
+      }
+
+      const uploadSessionResponse = await fetch('/api/trail-maintenance/reports/uploads', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          turnstileToken: turnstileToken || undefined,
+          files: photos.map((photo) => ({
+            originalFilename: photo.name,
+            contentType: photo.type,
+            byteSize: photo.size,
+          })),
+        }),
+      });
+      const uploadSessionBody = await readResponseBody(uploadSessionResponse);
+      if (!uploadSessionResponse.ok) {
+        throw new Error(errorMessage(uploadSessionBody, 'Photo uploads could not be prepared'));
+      }
+      const uploadSession = decodeUploadSession(uploadSessionBody);
+      if (!uploadSession || uploadSession.uploads.length !== photos.length) {
+        throw new Error('Photo upload service returned an invalid response');
+      }
+
+      await Promise.all(
+        uploadSession.uploads.map(async (upload, index) => {
+          const photo = photos[index];
+          if (!photo || upload.sortOrder !== index || upload.contentType !== photo.type) {
+            throw new Error('Photo upload mapping is invalid');
+          }
+          const uploadResponse = await fetch(upload.uploadUrl, {
+            method: 'PUT',
+            headers: {'Content-Type': upload.contentType},
+            body: photo,
+          });
+          if (!uploadResponse.ok) {
+            throw new Error(`Photo ${index + 1} could not be uploaded`);
+          }
+        }),
+      );
+
+      const reportResponse = await fetch('/api/trail-maintenance/reports', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          issueType,
+          issueTypeOther: formString(formData, 'issueTypeOther'),
+          observedAt: formString(formData, 'observedAt'),
+          trailSystemSlug,
+          trailSegmentSlug,
+          locationSource,
+          locationNotes: formString(formData, 'locationNotes'),
+          latitude,
+          longitude,
+          locationAccuracyMeters: accuracy,
+          description: formString(formData, 'description'),
+          reporterName: formString(formData, 'reporterName'),
+          reporterContact: formString(formData, 'reporterContact'),
+          uploadToken: uploadSession.uploadToken,
+        }),
+      });
+      const reportBody = await readResponseBody(reportResponse);
+      if (!reportResponse.ok) {
+        throw new Error(errorMessage(reportBody, 'Report could not be submitted'));
+      }
+      const report = decodeTrailReport(reportBody);
+      if (!report) {
+        throw new Error('Report service returned an invalid response');
+      }
+      router.push(`/report-trail-issue/${encodeURIComponent(report.publicId)}`);
     } catch (error) {
       setSubmitStatus({
         type: 'error',
         message: error instanceof Error ? error.message : 'Report could not be submitted',
       });
     } finally {
+      if (siteKey) {
+        resetTurnstile();
+      }
       setIsSubmitting(false);
     }
   };
@@ -154,7 +349,11 @@ export function PublicTrailIssueReportForm() {
   return (
     <Container maxWidth="md" sx={{py: {xs: 4, md: 7}}}>
       {siteKey && (
-        <Script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer />
+        <Script
+          src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+          strategy="afterInteractive"
+          onReady={renderTurnstile}
+        />
       )}
 
       <Paper className="dec-card" sx={{p: {xs: 2.5, md: 4}}}>
@@ -279,7 +478,7 @@ export function PublicTrailIssueReportForm() {
             <Typography sx={{fontWeight: 800}}>Photo of the issue</Typography>
             <Typography variant="body2" color="text.secondary">
               Upload one clear photo if you can. Add more only if it helps locate or explain the
-              issue.
+              issue. JPEG, PNG, and WebP photos up to 10 MB each are supported.
             </Typography>
             {Array.from({length: photoInputs}).map((_, index) => (
               <Button
@@ -290,7 +489,7 @@ export function PublicTrailIssueReportForm() {
                 sx={{justifySelf: 'start'}}
               >
                 {index === 0 ? 'Choose photo' : `Choose photo ${index + 1}`}
-                <input hidden name="photos" type="file" accept="image/*" />
+                <input hidden name="photos" type="file" accept="image/jpeg,image/png,image/webp" />
               </Button>
             ))}
             {photoInputs < TRAIL_MAINTENANCE_PHOTO_LIMIT && (
@@ -321,13 +520,15 @@ export function PublicTrailIssueReportForm() {
             </Grid>
           </Grid>
 
-          {siteKey && <Box className="cf-turnstile" data-sitekey={siteKey} />}
+          {siteKey && <Box ref={turnstileContainer} />}
 
           <Button
             type="submit"
             variant="contained"
             size="large"
-            disabled={isSubmitting || !issueType || !trailSegmentSlug}
+            disabled={
+              isSubmitting || !issueType || !trailSegmentSlug || Boolean(siteKey && !turnstileToken)
+            }
             startIcon={isSubmitting ? <CircularProgress size={18} /> : undefined}
             sx={{justifySelf: 'start'}}
           >

--- a/src/lib/trail-maintenance/constants.ts
+++ b/src/lib/trail-maintenance/constants.ts
@@ -2,6 +2,14 @@ export const TRAIL_SYSTEM_BIG_BRANCH = 'big-branch-bike-park';
 
 export const TRAIL_MAINTENANCE_PHOTO_LIMIT = 3;
 export const TRAIL_MAINTENANCE_PHOTO_MAX_BYTES = 10 * 1024 * 1024;
+export const TRAIL_MAINTENANCE_UPLOAD_TTL_SECONDS = 15 * 60;
+export const TRAIL_MAINTENANCE_TURNSTILE_ACTION = 'trail_report';
+
+export const trailMaintenancePhotoContentTypes: readonly string[] = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+];
 
 export const trailIssueTypes = [
   'trail_obstruction',

--- a/src/lib/trail-maintenance/r2.ts
+++ b/src/lib/trail-maintenance/r2.ts
@@ -1,9 +1,11 @@
 import {createHash, createHmac} from 'node:crypto';
 import {basename} from 'node:path';
 
+import {AwsClient} from 'aws4fetch';
 import sharp from 'sharp';
 
-import {TRAIL_MAINTENANCE_PHOTO_MAX_BYTES, TRAIL_MAINTENANCE_PHOTO_LIMIT} from './constants';
+import {TRAIL_MAINTENANCE_PHOTO_MAX_BYTES, TRAIL_MAINTENANCE_UPLOAD_TTL_SECONDS} from './constants';
+import type {StagedTrailPhoto} from './upload-session';
 
 export interface StoredTrailPhoto {
   readonly bucketName: string;
@@ -11,6 +13,12 @@ export interface StoredTrailPhoto {
   readonly originalFilename: string;
   readonly contentType: string;
   readonly byteSize: number;
+  readonly sortOrder: number;
+}
+
+export interface TrailPhotoUploadTarget {
+  readonly uploadUrl: string;
+  readonly contentType: string;
   readonly sortOrder: number;
 }
 
@@ -92,13 +100,6 @@ function canonicalUri(bucketName: string, objectKey: string): string {
     .join('/')}`;
 }
 
-function canonicalQuery(params: ReadonlyMap<string, string>): string {
-  return [...params.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => `${encodePathSegment(key)}=${encodePathSegment(value)}`)
-    .join('&');
-}
-
 function signingKey(secretAccessKey: string, dateStamp: string): Buffer {
   const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
   const regionKey = hmac(dateKey, R2_REGION);
@@ -134,6 +135,41 @@ function r2Endpoint(config: R2Config, objectKey: string): URL {
       objectKey,
     )}`,
   );
+}
+
+async function presignedObjectUrl({
+  config,
+  method,
+  objectKey,
+  expiresSeconds,
+  contentType,
+  now = new Date(),
+}: {
+  readonly config: R2Config;
+  readonly method: 'GET' | 'HEAD' | 'PUT' | 'DELETE';
+  readonly objectKey: string;
+  readonly expiresSeconds: number;
+  readonly contentType?: string;
+  readonly now?: Date;
+}): Promise<string> {
+  const url = r2Endpoint(config, objectKey);
+  url.searchParams.set('X-Amz-Expires', String(expiresSeconds));
+  const client = new AwsClient({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    service: R2_SERVICE,
+    region: R2_REGION,
+  });
+  const signed = await client.sign(url, {
+    method,
+    headers: contentType ? {'Content-Type': contentType} : undefined,
+    aws: {
+      signQuery: true,
+      allHeaders: contentType !== undefined,
+      datetime: formatAmzDate(now).amzDate,
+    },
+  });
+  return signed.url;
 }
 
 function putObjectHeaders({
@@ -210,6 +246,31 @@ async function putObject({
   }
 }
 
+async function deleteObject(config: R2Config, objectKey: string): Promise<void> {
+  const deleteUrl = await presignedObjectUrl({
+    config,
+    method: 'DELETE',
+    objectKey,
+    expiresSeconds: 60,
+  });
+  const response = await fetch(deleteUrl, {method: 'DELETE'});
+
+  if (!response.ok && response.status !== 404) {
+    throw new Error(`Cloudflare R2 delete failed with status ${response.status}`);
+  }
+}
+
+async function cleanupObjects(config: R2Config, objectKeys: readonly string[]): Promise<void> {
+  const results = await Promise.allSettled(
+    objectKeys.map((objectKey) => deleteObject(config, objectKey)),
+  );
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.warn('[TrailMaintenance] Failed to clean up R2 object:', result.reason);
+    }
+  }
+}
+
 export async function normalizeTrailPhoto(file: File): Promise<NormalizedTrailPhoto> {
   if (file.size <= 0 || file.size > TRAIL_MAINTENANCE_PHOTO_MAX_BYTES) {
     throw new TrailPhotoValidationError('Photos must be no larger than 10 MB');
@@ -260,12 +321,105 @@ export async function normalizeTrailPhoto(file: File): Promise<NormalizedTrailPh
   };
 }
 
-export async function storeTrailMaintenancePhotos({
+export async function createTrailPhotoUploadTargets({
+  files,
+  now = new Date(),
+}: {
+  readonly files: readonly StagedTrailPhoto[];
+  readonly now?: Date;
+}): Promise<TrailPhotoUploadTarget[]> {
+  if (files.length === 0) return [];
+
+  const config = getR2Config();
+  if (!config) {
+    throw new Error('Cloudflare R2 is not configured');
+  }
+
+  return Promise.all(
+    files.map(async (file) => ({
+      uploadUrl: await presignedObjectUrl({
+        config,
+        method: 'PUT',
+        objectKey: file.objectKey,
+        expiresSeconds: TRAIL_MAINTENANCE_UPLOAD_TTL_SECONDS,
+        contentType: file.contentType,
+        now,
+      }),
+      contentType: file.contentType,
+      sortOrder: file.sortOrder,
+    })),
+  );
+}
+
+async function loadStagedPhoto({
+  config,
+  file,
+}: {
+  readonly config: R2Config;
+  readonly file: StagedTrailPhoto;
+}): Promise<File> {
+  const headUrl = await presignedObjectUrl({
+    config,
+    method: 'HEAD',
+    objectKey: file.objectKey,
+    expiresSeconds: 60,
+  });
+  const headResponse = await fetch(headUrl, {method: 'HEAD'});
+  if (headResponse.status === 404) {
+    throw new TrailPhotoValidationError('A photo upload is missing or expired');
+  }
+  if (!headResponse.ok) {
+    throw new Error(`Cloudflare R2 metadata request failed with status ${headResponse.status}`);
+  }
+
+  const storedByteSize = Number(headResponse.headers.get('content-length'));
+  const storedContentType = headResponse.headers.get('content-type')?.split(';')[0]?.trim();
+  if (
+    !Number.isSafeInteger(storedByteSize) ||
+    storedByteSize <= 0 ||
+    storedByteSize > TRAIL_MAINTENANCE_PHOTO_MAX_BYTES ||
+    storedByteSize !== file.byteSize
+  ) {
+    throw new TrailPhotoValidationError('A photo upload has an invalid size');
+  }
+  if (storedContentType !== file.contentType) {
+    throw new TrailPhotoValidationError('A photo upload has an invalid content type');
+  }
+
+  const getUrl = await presignedObjectUrl({
+    config,
+    method: 'GET',
+    objectKey: file.objectKey,
+    expiresSeconds: 60,
+  });
+  const getResponse = await fetch(getUrl);
+  if (!getResponse.ok) {
+    throw new Error(`Cloudflare R2 download failed with status ${getResponse.status}`);
+  }
+
+  const downloadedByteSize = Number(getResponse.headers.get('content-length'));
+  if (
+    !Number.isSafeInteger(downloadedByteSize) ||
+    downloadedByteSize !== storedByteSize ||
+    downloadedByteSize > TRAIL_MAINTENANCE_PHOTO_MAX_BYTES
+  ) {
+    throw new TrailPhotoValidationError('A photo upload changed before it was processed');
+  }
+
+  const body = await getResponse.arrayBuffer();
+  if (body.byteLength !== storedByteSize) {
+    throw new TrailPhotoValidationError('A photo upload is incomplete');
+  }
+
+  return new File([body], file.originalFilename, {type: file.contentType});
+}
+
+export async function storeTrailMaintenancePhotosFromUploads({
   publicId,
   files,
 }: {
   readonly publicId: string;
-  readonly files: readonly File[];
+  readonly files: readonly StagedTrailPhoto[];
 }): Promise<StoredTrailPhoto[]> {
   if (files.length === 0) return [];
 
@@ -274,33 +428,51 @@ export async function storeTrailMaintenancePhotos({
     throw new Error('Cloudflare R2 is not configured');
   }
 
-  if (files.length > TRAIL_MAINTENANCE_PHOTO_LIMIT) {
-    throw new Error(`Upload up to ${TRAIL_MAINTENANCE_PHOTO_LIMIT} photos`);
-  }
+  const writtenObjectKeys: string[] = [];
+  try {
+    const normalizedPhotos: Array<{
+      readonly normalized: NormalizedTrailPhoto;
+      readonly sortOrder: number;
+    }> = [];
+    for (const file of files) {
+      const stagedFile = await loadStagedPhoto({config, file});
+      normalizedPhotos.push({
+        normalized: await normalizeTrailPhoto(stagedFile),
+        sortOrder: file.sortOrder,
+      });
+    }
 
-  const uploads: StoredTrailPhoto[] = [];
-  for (const [index, file] of files.entries()) {
-    const normalized = await normalizeTrailPhoto(file);
-    const objectKey = `trail-maintenance/${publicId}/${index + 1}.${normalized.extension}`;
-
-    await putObject({
+    const storedPhotos: StoredTrailPhoto[] = [];
+    try {
+      for (const {normalized, sortOrder} of normalizedPhotos) {
+        const objectKey = `trail-maintenance/${publicId}/${sortOrder + 1}.${normalized.extension}`;
+        await putObject({
+          config,
+          objectKey,
+          body: normalized.body,
+          contentType: normalized.contentType,
+        });
+        writtenObjectKeys.push(objectKey);
+        storedPhotos.push({
+          bucketName: config.bucketName,
+          objectKey,
+          originalFilename: normalized.originalFilename,
+          contentType: normalized.contentType,
+          byteSize: normalized.byteSize,
+          sortOrder,
+        });
+      }
+      return storedPhotos;
+    } catch (error) {
+      await cleanupObjects(config, writtenObjectKeys);
+      throw error;
+    }
+  } finally {
+    await cleanupObjects(
       config,
-      objectKey,
-      body: normalized.body,
-      contentType: normalized.contentType,
-    });
-
-    uploads.push({
-      bucketName: config.bucketName,
-      objectKey,
-      originalFilename: normalized.originalFilename,
-      contentType: normalized.contentType,
-      byteSize: normalized.byteSize,
-      sortOrder: index,
-    });
+      files.map((file) => file.objectKey),
+    );
   }
-
-  return uploads;
 }
 
 export async function getTrailPhotoSignedUrl({
@@ -312,37 +484,10 @@ export async function getTrailPhotoSignedUrl({
 }): Promise<string | null> {
   const config = getR2Config();
   if (!config || bucketName !== config.bucketName) return null;
-
-  const {dateStamp, amzDate} = formatAmzDate(new Date());
-  const credentialScope = `${dateStamp}/${R2_REGION}/${R2_SERVICE}/aws4_request`;
-  const params = new Map([
-    ['X-Amz-Algorithm', 'AWS4-HMAC-SHA256'],
-    ['X-Amz-Credential', `${config.accessKeyId}/${credentialScope}`],
-    ['X-Amz-Date', amzDate],
-    ['X-Amz-Expires', String(15 * 60)],
-    ['X-Amz-SignedHeaders', 'host'],
-  ]);
-  const host = `${config.accountId}.r2.cloudflarestorage.com`;
-  const canonicalRequest = [
-    'GET',
-    canonicalUri(config.bucketName, objectKey),
-    canonicalQuery(params),
-    `host:${host}`,
-    '',
-    'host',
-    'UNSIGNED-PAYLOAD',
-  ].join('\n');
-  params.set(
-    'X-Amz-Signature',
-    signature({
-      secretAccessKey: config.secretAccessKey,
-      dateStamp,
-      amzDate,
-      canonicalRequest,
-    }),
-  );
-
-  const url = r2Endpoint(config, objectKey);
-  url.search = canonicalQuery(params);
-  return url.toString();
+  return await presignedObjectUrl({
+    config,
+    method: 'GET',
+    objectKey,
+    expiresSeconds: 15 * 60,
+  });
 }

--- a/src/lib/trail-maintenance/request.ts
+++ b/src/lib/trail-maintenance/request.ts
@@ -1,0 +1,5 @@
+export function getTrailMaintenanceClientIp(request: Request): string | null {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) return forwardedFor.split(',')[0]?.trim() || null;
+  return request.headers.get('x-real-ip');
+}

--- a/src/lib/trail-maintenance/turnstile.ts
+++ b/src/lib/trail-maintenance/turnstile.ts
@@ -1,14 +1,18 @@
+import {z} from 'zod';
+
+import {TRAIL_MAINTENANCE_TURNSTILE_ACTION} from './constants';
+
 export interface TurnstileValidationResult {
   readonly ok: boolean;
   readonly reason?: string;
 }
 
-interface TurnstileSiteverifyResponse {
-  readonly success?: boolean;
-  readonly hostname?: string;
-  readonly action?: string;
-  readonly 'error-codes'?: string[];
-}
+const turnstileSiteverifyResponseSchema = z.object({
+  success: z.boolean().optional(),
+  hostname: z.string().optional(),
+  action: z.string().optional(),
+  'error-codes': z.array(z.string()).optional(),
+});
 
 function getAllowedHostnames(): ReadonlySet<string> {
   return new Set(
@@ -43,6 +47,11 @@ export async function verifyTrailMaintenanceTurnstile({
       : {ok: true, reason: 'Turnstile skipped outside production'};
   }
 
+  const allowedHostnames = getAllowedHostnames();
+  if (isProduction && allowedHostnames.size === 0) {
+    return {ok: false, reason: 'Turnstile hostname validation is not configured'};
+  }
+
   if (!token || token.length > 2048) {
     return {
       ok: false,
@@ -60,7 +69,7 @@ export async function verifyTrailMaintenanceTurnstile({
     body.set('remoteip', remoteIp);
   }
 
-  let result: TurnstileSiteverifyResponse;
+  let result: z.infer<typeof turnstileSiteverifyResponseSchema>;
   try {
     const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
       method: 'POST',
@@ -72,7 +81,11 @@ export async function verifyTrailMaintenanceTurnstile({
     if (!response.ok) {
       return {ok: false, reason: `Turnstile verification failed with ${response.status}`};
     }
-    result = (await response.json()) as TurnstileSiteverifyResponse;
+    const decoded = turnstileSiteverifyResponseSchema.safeParse(await response.json());
+    if (!decoded.success) {
+      return {ok: false, reason: 'Turnstile returned an invalid response'};
+    }
+    result = decoded.data;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Turnstile verification failed';
     return {ok: false, reason: message};
@@ -85,7 +98,10 @@ export async function verifyTrailMaintenanceTurnstile({
     };
   }
 
-  const allowedHostnames = getAllowedHostnames();
+  if (result.action !== TRAIL_MAINTENANCE_TURNSTILE_ACTION) {
+    return {ok: false, reason: 'Turnstile action is not allowed'};
+  }
+
   if (allowedHostnames.size > 0 && (!result.hostname || !allowedHostnames.has(result.hostname))) {
     return {ok: false, reason: 'Turnstile hostname is not allowed'};
   }

--- a/src/lib/trail-maintenance/upload-session.ts
+++ b/src/lib/trail-maintenance/upload-session.ts
@@ -1,0 +1,149 @@
+import {createHmac, randomUUID, timingSafeEqual} from 'node:crypto';
+
+import {z} from 'zod';
+
+import {
+  TRAIL_MAINTENANCE_PHOTO_LIMIT,
+  TRAIL_MAINTENANCE_PHOTO_MAX_BYTES,
+  TRAIL_MAINTENANCE_UPLOAD_TTL_SECONDS,
+  trailMaintenancePhotoContentTypes,
+} from './constants';
+
+const TOKEN_VERSION = 1;
+const PUBLIC_ID_PATTERN = /^[A-F0-9]{12}$/;
+const STAGING_KEY_PATTERN = /^trail-maintenance-staging\/[A-F0-9]{12}\/[1-3]-[a-f0-9-]{36}$/;
+
+export const trailPhotoUploadDescriptorSchema = z.object({
+  originalFilename: z.string().trim().min(1).max(255),
+  contentType: z.string().refine((value) => trailMaintenancePhotoContentTypes.includes(value), {
+    message: 'Photos must be JPEG, PNG, or WebP images',
+  }),
+  byteSize: z.number().int().positive().max(TRAIL_MAINTENANCE_PHOTO_MAX_BYTES, {
+    message: 'Photos must be no larger than 10 MB',
+  }),
+});
+
+export const trailPhotoUploadRequestSchema = z.object({
+  turnstileToken: z.string().trim().max(2048).optional(),
+  files: z.array(trailPhotoUploadDescriptorSchema).max(TRAIL_MAINTENANCE_PHOTO_LIMIT, {
+    message: `Upload up to ${TRAIL_MAINTENANCE_PHOTO_LIMIT} photos`,
+  }),
+});
+
+const stagedTrailPhotoSchema = trailPhotoUploadDescriptorSchema.extend({
+  objectKey: z.string().regex(STAGING_KEY_PATTERN),
+  sortOrder: z
+    .number()
+    .int()
+    .min(0)
+    .max(TRAIL_MAINTENANCE_PHOTO_LIMIT - 1),
+});
+
+const trailPhotoUploadSessionPayloadSchema = z
+  .object({
+    v: z.literal(TOKEN_VERSION),
+    publicId: z.string().regex(PUBLIC_ID_PATTERN),
+    iat: z.number().int(),
+    exp: z.number().int(),
+    files: z.array(stagedTrailPhotoSchema).max(TRAIL_MAINTENANCE_PHOTO_LIMIT),
+  })
+  .superRefine((payload, context) => {
+    for (const [index, file] of payload.files.entries()) {
+      if (
+        file.sortOrder !== index ||
+        !file.objectKey.startsWith(`trail-maintenance-staging/${payload.publicId}/${index + 1}-`)
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['files', index],
+          message: 'Invalid staged photo mapping',
+        });
+      }
+    }
+  });
+
+export type TrailPhotoUploadDescriptor = z.infer<typeof trailPhotoUploadDescriptorSchema>;
+export type StagedTrailPhoto = z.infer<typeof stagedTrailPhotoSchema>;
+export type TrailPhotoUploadSessionPayload = z.infer<typeof trailPhotoUploadSessionPayloadSchema>;
+
+export type TrailPhotoUploadSessionVerification =
+  | {readonly ok: true; readonly payload: TrailPhotoUploadSessionPayload}
+  | {readonly ok: false};
+
+function getUploadSigningSecret(): string {
+  const secret = process.env.TRAIL_MAINTENANCE_UPLOAD_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error('TRAIL_MAINTENANCE_UPLOAD_SECRET must be at least 32 characters');
+  }
+  return secret;
+}
+
+function signatureFor(encodedPayload: string): Buffer {
+  return createHmac('sha256', getUploadSigningSecret()).update(encodedPayload).digest();
+}
+
+function makePublicId(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 12).toUpperCase();
+}
+
+export function createTrailPhotoUploadSession(
+  files: readonly TrailPhotoUploadDescriptor[],
+  now: Date = new Date(),
+): {readonly token: string; readonly payload: TrailPhotoUploadSessionPayload} {
+  const issuedAt = Math.floor(now.getTime() / 1000);
+  const publicId = makePublicId();
+  const payload = trailPhotoUploadSessionPayloadSchema.parse({
+    v: TOKEN_VERSION,
+    publicId,
+    iat: issuedAt,
+    exp: issuedAt + TRAIL_MAINTENANCE_UPLOAD_TTL_SECONDS,
+    files: files.map((file, index) => ({
+      ...file,
+      objectKey: `trail-maintenance-staging/${publicId}/${index + 1}-${randomUUID()}`,
+      sortOrder: index,
+    })),
+  });
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = signatureFor(encodedPayload).toString('base64url');
+
+  return {token: `${encodedPayload}.${signature}`, payload};
+}
+
+export function verifyTrailPhotoUploadSession(
+  token: string,
+  now: Date = new Date(),
+): TrailPhotoUploadSessionVerification {
+  const [encodedPayload, encodedSignature, extraSegment] = token.split('.');
+  if (!encodedPayload || !encodedSignature || extraSegment !== undefined) {
+    return {ok: false};
+  }
+
+  let suppliedSignature: Buffer;
+  let decodedPayload: unknown;
+  try {
+    suppliedSignature = Buffer.from(encodedSignature, 'base64url');
+    decodedPayload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8'));
+  } catch {
+    return {ok: false};
+  }
+
+  const expectedSignature = signatureFor(encodedPayload);
+  if (
+    suppliedSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(suppliedSignature, expectedSignature)
+  ) {
+    return {ok: false};
+  }
+
+  const decoded = trailPhotoUploadSessionPayloadSchema.safeParse(decodedPayload);
+  if (!decoded.success) {
+    return {ok: false};
+  }
+
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  if (decoded.data.exp <= nowSeconds || decoded.data.iat > nowSeconds + 60) {
+    return {ok: false};
+  }
+
+  return {ok: true, payload: decoded.data};
+}

--- a/src/lib/trail-maintenance/validation.ts
+++ b/src/lib/trail-maintenance/validation.ts
@@ -22,62 +22,72 @@ const numberFromOptionalString = z.preprocess((value) => {
   return trimmed.length > 0 ? Number(trimmed) : undefined;
 }, z.number().finite().optional());
 
-export const publicTrailMaintenanceReportSchema = z
-  .object({
-    issueType: z.enum(trailIssueTypes),
-    issueTypeOther: trimmedOptional,
-    observedAt: z
-      .string()
-      .trim()
-      .min(1, 'Observed date and time is required')
-      .transform((value) => new Date(value))
-      .pipe(z.date()),
-    trailSystemSlug: z.string().trim().min(1, 'Trail system is required'),
-    trailSegmentSlug: z.string().trim().min(1, 'Trail is required'),
-    locationSource: z.enum(trailLocationSources).default('manual'),
-    locationNotes: trimmedOptional,
-    latitude: numberFromOptionalString,
-    longitude: numberFromOptionalString,
-    locationAccuracyMeters: numberFromOptionalString,
-    description: trimmedOptional,
-    reporterName: trimmedOptional,
-    reporterContact: trimmedOptional,
-    turnstileToken: trimmedOptional,
-  })
-  .superRefine((value, context) => {
-    const hasCoordinates = value.latitude !== undefined && value.longitude !== undefined;
-    if (!hasCoordinates && !value.locationNotes) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['locationNotes'],
-        message: 'Add location notes or use current location',
-      });
-    }
+const publicTrailMaintenanceReportFieldsSchema = z.object({
+  issueType: z.enum(trailIssueTypes),
+  issueTypeOther: trimmedOptional,
+  observedAt: z
+    .string()
+    .trim()
+    .min(1, 'Observed date and time is required')
+    .transform((value) => new Date(value))
+    .pipe(z.date()),
+  trailSystemSlug: z.string().trim().min(1, 'Trail system is required'),
+  trailSegmentSlug: z.string().trim().min(1, 'Trail is required'),
+  locationSource: z.enum(trailLocationSources).default('manual'),
+  locationNotes: trimmedOptional,
+  latitude: numberFromOptionalString,
+  longitude: numberFromOptionalString,
+  locationAccuracyMeters: numberFromOptionalString,
+  description: trimmedOptional,
+  reporterName: trimmedOptional,
+  reporterContact: trimmedOptional,
+});
 
-    if (value.issueType === 'other' && !value.issueTypeOther) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['issueTypeOther'],
-        message: 'Describe the issue type',
-      });
-    }
+function validatePublicReport(
+  value: z.infer<typeof publicTrailMaintenanceReportFieldsSchema>,
+  context: z.RefinementCtx,
+): void {
+  const hasCoordinates = value.latitude !== undefined && value.longitude !== undefined;
+  if (!hasCoordinates && !value.locationNotes) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['locationNotes'],
+      message: 'Add location notes or use current location',
+    });
+  }
 
-    if (value.latitude !== undefined && (value.latitude < -90 || value.latitude > 90)) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['latitude'],
-        message: 'Latitude is out of range',
-      });
-    }
+  if (value.issueType === 'other' && !value.issueTypeOther) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['issueTypeOther'],
+      message: 'Describe the issue type',
+    });
+  }
 
-    if (value.longitude !== undefined && (value.longitude < -180 || value.longitude > 180)) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['longitude'],
-        message: 'Longitude is out of range',
-      });
-    }
-  });
+  if (value.latitude !== undefined && (value.latitude < -90 || value.latitude > 90)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['latitude'],
+      message: 'Latitude is out of range',
+    });
+  }
+
+  if (value.longitude !== undefined && (value.longitude < -180 || value.longitude > 180)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['longitude'],
+      message: 'Longitude is out of range',
+    });
+  }
+}
+
+export const publicTrailMaintenanceReportSchema = publicTrailMaintenanceReportFieldsSchema
+  .extend({turnstileToken: trimmedOptional})
+  .superRefine(validatePublicReport);
+
+export const publicTrailMaintenanceReportSubmissionSchema = publicTrailMaintenanceReportFieldsSchema
+  .extend({uploadToken: z.string().trim().min(1).max(4096)})
+  .superRefine(validatePublicReport);
 
 export const trailMaintenanceListQuerySchema = z.object({
   status: z.enum(trailIssueStatuses).optional(),
@@ -93,6 +103,8 @@ export const trailMaintenanceUpdateSchema = z.object({
   internalNote: z.string().trim().max(4000).optional(),
 });
 
-export type PublicTrailMaintenanceReportInput = z.infer<typeof publicTrailMaintenanceReportSchema>;
+export type PublicTrailMaintenanceReportInput = z.infer<
+  typeof publicTrailMaintenanceReportFieldsSchema
+>;
 export type TrailMaintenanceListQuery = z.infer<typeof trailMaintenanceListQuerySchema>;
 export type TrailMaintenanceUpdateInput = z.infer<typeof trailMaintenanceUpdateSchema>;


### PR DESCRIPTION
## Summary

- create a Turnstile-gated, signed 15-minute upload session for up to three photos
- upload photo bytes directly from the browser to private R2 staging keys, keeping the Netlify report request small
- validate stored size and content type, decode and normalize images to WebP, and remove staging objects during report finalization
- handle empty or non-JSON API responses without surfacing `Unexpected end of JSON input`
- document the required R2 CORS policy, staging lifecycle rule, and upload-signing secret

## Why

The existing multipart report request sent all photo bytes through the Netlify function. A single sufficiently large photo—and especially the supported three-photo case—can exceed Netlify's request-size limit before application code runs. Direct browser-to-R2 uploads remove the image payload from that request path.

## Deployment requirements

- set `TRAIL_MAINTENANCE_UPLOAD_SECRET` to an independent random value of at least 32 characters
- apply the documented R2 CORS policy for every production or preview origin that will upload photos
- add an R2 lifecycle rule that expires `trail-maintenance-staging/` objects after one day
- ensure every production/preview hostname is included in `CLOUDFLARE_TURNSTILE_ALLOWED_HOSTNAMES`

## Verification

- `pnpm tsgo`
- `pnpm lint`
- `pnpm test:run` (294 tests)
- `pnpm fmt:check`
- `pnpm build`
