### PR TITLE
Increase trail photo upload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Down East Cyclists website is built with Next.js and deployed on Netlify. It
 ### Trail Maintenance
 
 - **Report Trail Issue** (`/report-trail-issue`): Public form for riders to report Big Branch trail maintenance issues
-  - Supports issue type selection, observed date/time, trail segment, location notes, browser geolocation, optional reporter contact, and up to three photos
+  - Supports issue type selection, observed date/time, trail segment, location notes, browser geolocation, optional reporter contact, and up to three 20 MB photos
   - Uses Cloudflare Turnstile when configured
   - Uploads photos directly from the browser to short-lived private R2 staging objects, then validates and normalizes them server-side when the report is finalized
   - Redirects submitters to a public confirmation/status page (`/report-trail-issue/[publicId]`)

--- a/src/__tests__/lib/trail-upload-session.test.ts
+++ b/src/__tests__/lib/trail-upload-session.test.ts
@@ -62,7 +62,12 @@ describe('trail photo upload sessions', () => {
     ).toBe(false);
     expect(
       trailPhotoUploadRequestSchema.safeParse({
-        files: [{...PHOTO, byteSize: 10 * 1024 * 1024 + 1}],
+        files: [{...PHOTO, byteSize: 11_176_013}],
+      }).success,
+    ).toBe(true);
+    expect(
+      trailPhotoUploadRequestSchema.safeParse({
+        files: [{...PHOTO, byteSize: 20 * 1024 * 1024 + 1}],
       }).success,
     ).toBe(false);
   });

--- a/src/components/trail-maintenance/PublicTrailIssueReportForm.tsx
+++ b/src/components/trail-maintenance/PublicTrailIssueReportForm.tsx
@@ -259,7 +259,7 @@ export function PublicTrailIssueReportForm() {
       }
       for (const photo of photos) {
         if (photo.size > TRAIL_MAINTENANCE_PHOTO_MAX_BYTES) {
-          throw new Error('Photos must be no larger than 10 MB');
+          throw new Error('Photos must be no larger than 20 MB');
         }
         if (!trailMaintenancePhotoContentTypes.includes(photo.type)) {
           throw new Error('Photos must be JPEG, PNG, or WebP images');
@@ -478,7 +478,7 @@ export function PublicTrailIssueReportForm() {
             <Typography sx={{fontWeight: 800}}>Photo of the issue</Typography>
             <Typography variant="body2" color="text.secondary">
               Upload one clear photo if you can. Add more only if it helps locate or explain the
-              issue. JPEG, PNG, and WebP photos up to 10 MB each are supported.
+              issue. JPEG, PNG, and WebP photos up to 20 MB each are supported.
             </Typography>
             {Array.from({length: photoInputs}).map((_, index) => (
               <Button

--- a/src/lib/trail-maintenance/constants.ts
+++ b/src/lib/trail-maintenance/constants.ts
@@ -1,7 +1,7 @@
 export const TRAIL_SYSTEM_BIG_BRANCH = 'big-branch-bike-park';
 
 export const TRAIL_MAINTENANCE_PHOTO_LIMIT = 3;
-export const TRAIL_MAINTENANCE_PHOTO_MAX_BYTES = 10 * 1024 * 1024;
+export const TRAIL_MAINTENANCE_PHOTO_MAX_BYTES = 20 * 1024 * 1024;
 export const TRAIL_MAINTENANCE_UPLOAD_TTL_SECONDS = 15 * 60;
 export const TRAIL_MAINTENANCE_TURNSTILE_ACTION = 'trail_report';
 

--- a/src/lib/trail-maintenance/r2.ts
+++ b/src/lib/trail-maintenance/r2.ts
@@ -273,7 +273,7 @@ async function cleanupObjects(config: R2Config, objectKeys: readonly string[]): 
 
 export async function normalizeTrailPhoto(file: File): Promise<NormalizedTrailPhoto> {
   if (file.size <= 0 || file.size > TRAIL_MAINTENANCE_PHOTO_MAX_BYTES) {
-    throw new TrailPhotoValidationError('Photos must be no larger than 10 MB');
+    throw new TrailPhotoValidationError('Photos must be no larger than 20 MB');
   }
 
   const input = Buffer.from(await file.arrayBuffer());

--- a/src/lib/trail-maintenance/upload-session.ts
+++ b/src/lib/trail-maintenance/upload-session.ts
@@ -19,7 +19,7 @@ export const trailPhotoUploadDescriptorSchema = z.object({
     message: 'Photos must be JPEG, PNG, or WebP images',
   }),
   byteSize: z.number().int().positive().max(TRAIL_MAINTENANCE_PHOTO_MAX_BYTES, {
-    message: 'Photos must be no larger than 10 MB',
+    message: 'Photos must be no larger than 20 MB',
   }),
 });
 


### PR DESCRIPTION
## Summary

- increase the trail-report photo source limit from 10 MiB to 20 MiB per image
- apply the limit consistently in browser validation, signed upload sessions, staged R2 object verification, and server-side image processing
- update the form copy and README
- add regression coverage for the 11,176,013-byte JPEG produced when macOS converted the reported 6.2 MB iPhone HEIF image

## Why

Apple Photos may convert an efficient HEIF original into a substantially larger JPEG when passing it to the browser. The reported 6.2 MB HEIF became a 10.66 MiB JPEG and was rejected locally by the previous 10 MiB application limit before any request reached the site or R2. Since photo bytes now upload directly to R2, a 20 MiB per-photo source limit avoids this common conversion edge case without reintroducing Netlify's request-body limit.

The existing three-photo cap, JPEG/PNG/WebP allowlist, 40-megapixel decode limit, server-side validation, and WebP normalization remain unchanged.

## Verification

- `pnpm tsgo`
- `pnpm lint`
- `pnpm test:run` (294 tests)
- `pnpm fmt:check`
- `pnpm build`
